### PR TITLE
Fix duplicate viewport meta

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Artist Explorer</title>
   <link rel="stylesheet" href="style.css">
   <link rel="icon" type="image/png" href="favicon.png">


### PR DESCRIPTION
## Summary
- remove redundant meta viewport tag

## Testing
- `grep -n viewport -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_6867456366d8832c98f485da983f1923