### PR TITLE
Add basic node test for sidebar updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "kexplorer",
+  "version": "1.0.0",
+  "description": "The **Kink Artist Explorer** is a mobile-first, degrading tool for discovering NSFW artists on Danbooru based on humiliating kink tags like femdom, chastity, and sissy training.",
+  "main": "script.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/script.js
+++ b/script.js
@@ -1,3 +1,6 @@
+if (typeof window === 'undefined') {
+  global.window = {};
+}
 window._danbooruUnavailable = false;
 
 let copiedArtists = new Set();
@@ -61,6 +64,15 @@ function updateCopiedSidebar() {
   });
 }
 
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = {
+    updateCopiedSidebar,
+    _setAllArtists: (val) => { allArtists = val; },
+    _setCopiedArtists: (val) => { copiedArtists = val; },
+    _setCopiedSidebar: (val) => { copiedSidebar = val; }
+  };
+}
+
 function showNoEntriesMsg(element, msg = "No valid entries") {
   element.style.display = "none";
   let span = element.nextSibling;
@@ -75,7 +87,8 @@ function showNoEntriesMsg(element, msg = "No valid entries") {
   span.style.display = "block";
 }
 
-document.addEventListener("DOMContentLoaded", () => {
+if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", () => {
   const kinkTags = [
     "femdom", "chastity_cage", "trap",
     "anal_object_insertion", "prostate_milking", "gagged", "dominatrix", "humiliation", "lactation",
@@ -962,4 +975,5 @@ document.addEventListener("DOMContentLoaded", () => {
     kiss.className = 'lipstick-kiss';
     document.body.appendChild(kiss);
   }
-});
+  });
+}

--- a/tests/updateCopiedSidebar.test.js
+++ b/tests/updateCopiedSidebar.test.js
@@ -1,0 +1,51 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const sidebarModule = require('../script.js');
+const { updateCopiedSidebar, _setAllArtists, _setCopiedArtists, _setCopiedSidebar } = sidebarModule;
+
+function createStubDocument() {
+  return {
+    createElement(tag) {
+      const el = {
+        tagName: tag.toUpperCase(),
+        children: [],
+        style: {},
+        appendChild(child) {
+          this.children.push(child);
+        },
+      };
+      Object.defineProperty(el, 'src', {
+        get() { return this._src; },
+        set(v) { this._src = v; },
+      });
+      return el;
+    },
+    createTextNode(text) {
+      return { nodeType: 3, textContent: text };
+    },
+  };
+}
+
+test('updateCopiedSidebar creates images with correct src', () => {
+  const document = createStubDocument();
+  global.document = document;
+  const sidebar = {
+    children: [],
+    appendChild(child) { this.children.push(child); },
+    set innerHTML(_) { this.children = []; },
+  };
+
+  _setCopiedSidebar(sidebar);
+  _setAllArtists([
+    { artistName: 'foo_bar', thumbnailUrl: 'img/foo.jpg' },
+    { artistName: 'baz', thumbnailUrl: 'img/baz.jpg' }
+  ]);
+  _setCopiedArtists(new Set(['foo_bar', 'baz']));
+
+  updateCopiedSidebar();
+
+  assert.equal(sidebar.children.length, 2);
+  assert.equal(sidebar.children[0].children[0].src, 'img/foo.jpg');
+  assert.equal(sidebar.children[1].children[0].src, 'img/baz.jpg');
+});


### PR DESCRIPTION
## Summary
- initialize npm package with node test script
- export helper functions from `script.js`
- guard browser-only code for Node execution
- add unit test for `updateCopiedSidebar`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867456bd618832ca79f64122cdb7b53