### PR TITLE
Ensure fallback to artist image on tag miss

### DIFF
--- a/modules/gallery.js
+++ b/modules/gallery.js
@@ -71,7 +71,15 @@ function setBestImage(artist, img) {
     } catch {}
   }
 
-  function processApiData(data) {
+  function showNoEntries() {
+    img.style.display = "none";
+    img.src = "fallback.jpg";
+    setTimeout(() => {
+      img.style.display = "block";
+    }, 100);
+  }
+
+  function processApiData(data, isFallback = false) {
     const validPosts = Array.isArray(data)
       ? data.filter((post) => {
           const url = post?.large_file_url || post?.file_url;
@@ -81,16 +89,19 @@ function setBestImage(artist, img) {
       : [];
 
     if (validPosts.length === 0) {
-      showNoEntries();
+      if (!isFallback && selectedTags.length > 0) {
+        // Retry using only the artist name ordered by score
+        fetchArtistImages(artist.artistName)
+          .then((fallbackData) => {
+            processApiData(fallbackData, true);
+          })
+          .catch(() => {
+            showNoEntries();
+          });
+      } else {
+        showNoEntries();
+      }
       return;
-    }
-
-    function showNoEntries() {
-      img.style.display = "none";
-      img.src = "fallback.jpg";
-      setTimeout(() => {
-        img.style.display = "block";
-      }, 100);
     }
 
     function tryLoadUrls(urls, index = 0) {


### PR DESCRIPTION
## Summary
- make gallery thumbnails retry with artist-only posts when tagged fetches return no valid images

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868a86d4190832c98818ee0d06c6c5c