### PR TITLE
Fix infinite scroll and add image tags in viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,12 +31,18 @@
           />
           
           <label for="artist-name-filter" class="visually-hidden">Filter by artist name</label>
-          <input 
-            type="text" 
-            id="artist-name-filter" 
+          <input
+            type="text"
+            id="artist-name-filter"
             placeholder="Filter by artist name..."
             aria-describedby="artist-filter-help"
           >
+
+          <label for="sort-by" class="visually-hidden">Sort artists</label>
+          <select id="sort-by" aria-label="Sort artists">
+            <option value="name">Sort: Name</option>
+            <option value="count">Sort: Total Images</option>
+          </select>
         </div>
         
         <div id="tag-buttons" role="group" aria-label="Available tags"></div>

--- a/main.js
+++ b/main.js
@@ -26,6 +26,7 @@ import {
   setAllArtists as setGalleryArtists,
   setGetActiveTagsCallback,
   setGetArtistNameFilterCallback,
+  setSortMode,
 } from "./modules/gallery.js";
 import {
   initUI,
@@ -134,5 +135,13 @@ if (sidebarCloseBtn && copiedSidebar) {
   sidebarCloseBtn.addEventListener("click", () => {
     copiedSidebar.classList.remove("visible");
     document.body.classList.remove("sidebar-open");
+  });
+}
+
+const sortSelect = document.getElementById("sort-by");
+if (sortSelect) {
+  sortSelect.addEventListener("change", (e) => {
+    setSortMode(e.target.value);
+    filterArtists(true);
   });
 }

--- a/modules/ui.js
+++ b/modules/ui.js
@@ -161,10 +161,18 @@ function createModal(content, className = "modal") {
 function createFullscreenViewer() {
   const wrapper = document.createElement("div");
   wrapper.className = "fullscreen-wrapper";
-  
+
+  const content = document.createElement("div");
+  content.className = "zoom-content";
+
+  const tagList = document.createElement("div");
+  tagList.className = "zoom-tags";
+
   const img = document.createElement("img");
   img.className = "fullscreen-img";
-  wrapper.appendChild(img);
+
+  content.append(tagList, img);
+  wrapper.appendChild(content);
 
   const noEntriesMsg = document.createElement("span");
   noEntriesMsg.style.display = "none";
@@ -207,6 +215,7 @@ function createFullscreenViewer() {
   return {
     wrapper,
     img,
+    tagList,
     noEntriesMsg,
     closeBtn,
     prevBtn,

--- a/style.css
+++ b/style.css
@@ -668,6 +668,22 @@ main {
   justify-content: center;
 }
 
+.zoom-content {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  max-height: 92vh;
+}
+
+.zoom-tags {
+  overflow-y: auto;
+  max-height: 92vh;
+  color: #fff0f6;
+  font-size: 0.9rem;
+  line-height: 1.3;
+  max-width: 20vw;
+}
+
 .fullscreen-img {
   max-width: 92%;
   max-height: 92%;


### PR DESCRIPTION
## Summary
- remove extra infinite scroll handler to stop duplicate artists
- show tags next to zoomed images
- allow sorting by total image count
- fetch complete image counts across pages
- expose sort dropdown in UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b4187175c832caa0ee1346424ca3e