### PR TITLE
Fix gallery filter updates

### DIFF
--- a/modules/gallery.js
+++ b/modules/gallery.js
@@ -17,6 +17,7 @@ const artistsPerPage = 24;
 let filtered = [];
 let isFetching = false;
 let sortMode = "name";
+let filterGeneration = 0;
 
 // DOM references
 let artistGallery = null;
@@ -460,12 +461,14 @@ function renderArtistsPage() {
  */
 async function filterArtists(reset = true, force = false) {
   if (!artistGallery) return;
+  const generation = ++filterGeneration;
   if (isFetching) {
     const existing = artistGallery.querySelector(".gallery-spinner");
     if (!existing) {
       artistGallery.appendChild(createSpinner());
     }
-    return;
+    // Do not return; allow new filtering to proceed but results from prior
+    // generations will be ignored
   }
 
   let spinner;
@@ -514,9 +517,10 @@ async function filterArtists(reset = true, force = false) {
     );
 
     // Always fetch counts for the current filtered artists
-    async function fetchInBatches(artists, batchSize = 5, delayMs = 1000) {
+    async function fetchInBatches(artists, batchSize = 5, delayMs = 1000, gen) {
       const { getArtistImageCount } = await import("./api.js");
       for (let i = 0; i < artists.length; i += batchSize) {
+        if (gen !== filterGeneration) return;
         const batch = artists.slice(i, i + batchSize);
         await Promise.all(
           batch.map(async (artist) => {
@@ -543,6 +547,9 @@ async function filterArtists(reset = true, force = false) {
             } else {
               artist._imageCount = totalCount;
             }
+            if (gen !== filterGeneration) {
+              return;
+            }
           })
         );
         if (i + batchSize < artists.length) {
@@ -554,9 +561,10 @@ async function filterArtists(reset = true, force = false) {
     renderArtistsPage(); // Render immediately
 
     if (reset) {
-      await fetchInBatches(filtered).catch((e) => {
+      await fetchInBatches(filtered, 5, 1000, generation).catch((e) => {
         console.error("Batch fetch failed:", e);
       });
+      if (generation !== filterGeneration) return;
       if (sortMode === "count") {
         filtered.sort(
           (a, b) => (b._totalImageCount || 0) - (a._totalImageCount || 0)
@@ -566,14 +574,25 @@ async function filterArtists(reset = true, force = false) {
       renderArtistsPage();
     } else if (force) {
       // Reset and fetch new counts
-      fetchInBatches(filtered);
+      fetchInBatches(filtered, 5, 1000, generation).then(() => {
+        if (generation !== filterGeneration) return;
+        if (sortMode === "count") {
+          filtered.sort(
+            (a, b) => (b._totalImageCount || 0) - (a._totalImageCount || 0)
+          );
+          currentArtistPage = 0;
+        }
+        renderArtistsPage();
+      });
     }
   } catch (error) {
     console.warn("filterArtists failed", error);
   } finally {
-    const remaining = artistGallery.querySelector(".gallery-spinner");
-    if (remaining) remaining.remove();
-    isFetching = false;
+    if (generation === filterGeneration) {
+      const remaining = artistGallery.querySelector(".gallery-spinner");
+      if (remaining) remaining.remove();
+      isFetching = false;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- improve gallery filtering concurrency with generation id
- ensure counts and sorting refresh correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b7135acd0832cadb7aded01bad5d8