### PR TITLE
Remove debug call from api.js

### DIFF
--- a/modules/api.js
+++ b/modules/api.js
@@ -210,6 +210,3 @@ export {
   loadAppData,
 };
 
-getArtistImageCount("any_known_artist_name")
-  .then(console.log)
-  .catch(console.error);


### PR DESCRIPTION
## Summary
- remove leftover `getArtistImageCount` debug call from `modules/api.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b77c85d40832ca76fd90adbd70a07