### PR TITLE
Add script for updating artist post counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ The **Kink Artist Explorer** is a mobile-first, degrading tool for discovering N
 
 Upload contents to GitHub Pages and open the site. Click your kinks. Get degraded. Try to stop.
 
+To refresh artist post counts stored in `artists.json`, run:
+
+```bash
+node scripts/updateCounts.js
+```
+
 ## 🖤 Credits
 
 - Audio: SoundCloud

--- a/scripts/updateCounts.js
+++ b/scripts/updateCounts.js
@@ -1,0 +1,21 @@
+import fs from 'fs/promises';
+import { getArtistImageCount } from '../modules/api.js';
+
+async function updateCounts() {
+  const filePath = new URL('../artists.json', import.meta.url);
+  const data = JSON.parse(await fs.readFile(filePath, 'utf8'));
+
+  for (const artist of data) {
+    try {
+      const count = await getArtistImageCount(artist.artistName);
+      artist.postCount = count;
+      console.log(`${artist.artistName}: ${count}`);
+    } catch (err) {
+      console.error(`Failed to get count for ${artist.artistName}:`, err);
+    }
+  }
+
+  await fs.writeFile(filePath, JSON.stringify(data, null, 2) + '\n');
+}
+
+updateCounts();


### PR DESCRIPTION
## Summary
- add `scripts/updateCounts.js` to populate `postCount` for each artist
- document the script usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b77b09b74832c9b87cb0bf6ed9e76