### PR TITLE
Add theme toggle with incognito mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ The **Kink Artist Explorer** is a mobile-first, degrading tool for discovering N
 - 🖼 Live Artist Card Fetching from Danbooru + Zele
 - 🎧 Embedded Femdom Hypnosis (6 rotating tracks)
 - 💬 Taunting JRPG-style Bubble Insults
-- 🎀 Feminine UI Design (coming soon)
+- 🎀 Feminine UI Design
+- 🌗 Incognito Theme Toggle
 
 ## 🚀 Use
 

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 </head>
 
-<body>
+<body class="fem-theme">
   <!-- Background decoration -->
   <div id="background-blur" aria-hidden="true"></div>
   
@@ -120,6 +120,7 @@
     <div class="toggle-buttons-container">
       <button class="sidebar-toggle" aria-label="Show copied artists sidebar">🎀</button>
       <button class="audio-toggle" aria-label="Show audio panel">🎶</button>
+      <button class="theme-toggle" aria-label="Toggle theme">🌓</button>
     </div>
     
     <button id="back-to-top" title="Back to top" aria-label="Scroll to top">

--- a/main.js
+++ b/main.js
@@ -145,3 +145,22 @@ if (sortSelect) {
     filterArtists(true);
   });
 }
+
+// Theme toggling
+const themeToggle = document.querySelector(".theme-toggle");
+const bodyEl = document.body;
+const savedTheme = localStorage.getItem("theme");
+if (savedTheme === "incognito") {
+  bodyEl.classList.add("incognito-theme");
+  bodyEl.classList.remove("fem-theme");
+}
+if (themeToggle) {
+  themeToggle.addEventListener("click", () => {
+    bodyEl.classList.toggle("incognito-theme");
+    bodyEl.classList.toggle("fem-theme");
+    const current = bodyEl.classList.contains("incognito-theme")
+      ? "incognito"
+      : "fem";
+    localStorage.setItem("theme", current);
+  });
+}

--- a/style.css
+++ b/style.css
@@ -53,6 +53,30 @@
   --z-tooltip: 10001;
 }
 
+/* Incognito theme overrides */
+body.incognito-theme {
+  --primary-pink: #555555;
+  --secondary-pink: #666666;
+  --light-pink: #333333;
+  --pale-pink: #222222;
+  --cream-pink: #444444;
+  --dark-pink: #f0f0f0;
+  --accent-pink: #888888;
+  background: #111111;
+  color: #f0f0f0;
+}
+
+/* Fem theme for explicit toggling */
+body.fem-theme {
+  --primary-pink: #fd7bc5;
+  --secondary-pink: #ffb6d5;
+  --light-pink: #ffe0f6;
+  --pale-pink: #ffd6f6;
+  --cream-pink: #fff0fa;
+  --dark-pink: #a0005a;
+  --accent-pink: #d63384;
+}
+
 /* Accessibility helpers */
 .visually-hidden {
   position: absolute;
@@ -84,6 +108,7 @@ body {
   color: var(--dark-pink);
   overflow-x: hidden;
   line-height: 1.6;
+  animation: fade-in 0.4s ease-out;
 }
 
 html, body {
@@ -992,6 +1017,14 @@ body .lipstick-kiss {
   filter: drop-shadow(0 0 2px #ffb6d5);
   pointer-events: none;
 }
+.theme-toggle::after {
+  content: " 🌗";
+  font-size: 1.2em;
+  margin-left: 0.3em;
+  vertical-align: middle;
+  filter: drop-shadow(0 0 2px #ffb6d5);
+  pointer-events: none;
+}
 #back-to-top::after {
   content: " 💋";
   font-size: 1.1em;
@@ -1480,4 +1513,13 @@ input[type="text"]:focus, input[type="search"]:focus {
   background-size: 1.3em;
   background-position: right 1em center;
   padding-right: 3em;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }


### PR DESCRIPTION
## Summary
- support theme toggling between feminine and incognito modes
- add theme toggle button to UI
- animate page load with fade‑in
- document new incognito theme feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686beda5f898832ca18bcf35a4983316