### PR TITLE
Introduce tag explorer modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The **Kink Artist Explorer** is a mobile-first, degrading tool for discovering N
 - 🌗 Incognito Theme Toggle
 - 🖤 Plain Backgrounds in Incognito Mode
 - ✨ Animated Gallery Cards
+- 🗂 Tag Explorer modal for browsing all tags
 
 ## 🚀 Use
 

--- a/index.html
+++ b/index.html
@@ -43,6 +43,8 @@
             <option value="name">Sort: Name</option>
             <option value="count">Sort: Total Images</option>
           </select>
+
+          <button id="open-tag-explorer" type="button">Browse Tags</button>
         </div>
         
         <div id="tag-buttons" role="group" aria-label="Available tags"></div>

--- a/main.js
+++ b/main.js
@@ -33,6 +33,7 @@ import {
   setupInfiniteScroll,
   setupBackgroundRotation,
 } from "./modules/ui.js";
+import { openTagExplorer, setAllArtists as setExplorerArtists } from "./modules/tag-explorer.js";
 import { loadAppData } from "./modules/api.js";
 
 /**
@@ -54,6 +55,7 @@ async function initApp() {
     setSidebarArtists(artists);
     setTagsArtists(artists);
     setGalleryArtists(artists);
+    setExplorerArtists(artists);
 
     // Set up callback dependencies
     setRenderArtistsCallback(filterArtists);
@@ -119,6 +121,7 @@ window.kexplorer = {
   setRandomBackground,
   getActiveTags,
   renderTagButtons,
+  openTagExplorer,
 };
 
 const audioToggleBtn = document.querySelector(".audio-toggle");
@@ -143,6 +146,13 @@ if (sortSelect) {
   sortSelect.addEventListener("change", (e) => {
     setSortMode(e.target.value);
     filterArtists(true);
+  });
+}
+
+const tagExplorerBtn = document.getElementById("open-tag-explorer");
+if (tagExplorerBtn) {
+  tagExplorerBtn.addEventListener("click", () => {
+    openTagExplorer();
   });
 }
 

--- a/modules/tag-explorer.js
+++ b/modules/tag-explorer.js
@@ -1,0 +1,83 @@
+import { getActiveTags, getKinkTags, toggleTag } from './tags.js';
+import { createModal } from './ui.js';
+
+let allArtists = [];
+
+function setAllArtists(artists) {
+  allArtists = Array.isArray(artists) ? artists : [];
+}
+
+function getTagCounts() {
+  const counts = {};
+  allArtists.forEach((a) => {
+    (a.kinkTags || []).forEach((t) => {
+      counts[t] = (counts[t] || 0) + 1;
+    });
+  });
+  return counts;
+}
+
+function openTagExplorer() {
+  const counts = getTagCounts();
+  const allTags = getKinkTags();
+  const active = getActiveTags();
+
+  let sortMode = 'name';
+
+  const container = document.createElement('div');
+  container.className = 'tag-explorer';
+
+  const header = document.createElement('div');
+  header.className = 'tag-explorer-header';
+
+  const title = document.createElement('h3');
+  title.textContent = 'Tags';
+  header.appendChild(title);
+
+  const sortSelect = document.createElement('select');
+  sortSelect.innerHTML = `<option value="name">Sort: Name</option><option value="count">Sort: Count</option>`;
+  sortSelect.onchange = () => {
+    sortMode = sortSelect.value;
+    renderList();
+  };
+  header.appendChild(sortSelect);
+
+  container.appendChild(header);
+
+  const list = document.createElement('div');
+  list.className = 'tag-explorer-tags';
+  container.appendChild(list);
+
+  function renderList() {
+    list.innerHTML = '';
+    const tags = allTags.slice().sort((a, b) => {
+      if (sortMode === 'count') {
+        return (counts[b] || 0) - (counts[a] || 0);
+      }
+      return a.localeCompare(b);
+    });
+    tags.forEach((tag) => {
+      const btn = document.createElement('button');
+      btn.className = 'tag-button';
+      btn.textContent = `${tag.replace(/_/g, ' ')} (${counts[tag] || 0})`;
+      if (active.has(tag)) btn.classList.add('active');
+      btn.onclick = () => {
+        toggleTag(tag);
+        if (active.has(tag)) {
+          active.delete(tag);
+          btn.classList.remove('active');
+        } else {
+          active.add(tag);
+          btn.classList.add('active');
+        }
+      };
+      list.appendChild(btn);
+    });
+  }
+
+  const modal = createModal(container, 'modal');
+  document.body.appendChild(modal);
+  renderList();
+}
+
+export { openTagExplorer, setAllArtists };

--- a/modules/tags.js
+++ b/modules/tags.js
@@ -226,6 +226,22 @@ function clearAllTags() {
 }
 
 /**
+ * Toggles a single tag on or off
+ */
+function toggleTag(tag) {
+  if (activeTags.has(tag)) {
+    activeTags.delete(tag);
+  } else {
+    activeTags.add(tag);
+    spawnBubble(tag);
+  }
+  renderTagButtons();
+  if (renderArtists) renderArtists(true);
+  if (setRandomBackground) setRandomBackground();
+  if (navigator.vibrate) navigator.vibrate(50);
+}
+
+/**
  * Handles tag search input with debouncing
  */
 function handleTagSearch(value) {
@@ -365,5 +381,6 @@ export {
   getSearchFilter,
   getArtistNameFilter,
   getKinkTags,
+  toggleTag,
   spawnBubble,
 };

--- a/style.css
+++ b/style.css
@@ -1572,3 +1572,46 @@ input[type="text"]:focus, input[type="search"]:focus {
     transform: translateY(0);
   }
 }
+
+/* Modal styles for tag explorer */
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10050;
+}
+.modal-content {
+  background: var(--cream-pink);
+  color: var(--dark-pink);
+  padding: var(--spacing-lg);
+  border-radius: var(--border-radius-lg);
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: var(--shadow-lg);
+}
+
+.tag-explorer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  min-width: 260px;
+}
+.tag-explorer-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+.tag-explorer-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  justify-content: center;
+}
+.tag-explorer-tags .tag-button {
+  flex: 0 1 auto;
+}


### PR DESCRIPTION
## Summary
- add Tag Explorer modal for browsing all tags
- allow toggling tags programmatically
- wire Tag Explorer into main UI
- document new feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c056508ec832c8c9b0ef3bed2d0ea