### PR TITLE
Introduce tag explorer modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The **Kink Artist Explorer** is a mobile-first, degrading tool for discovering N
 - 🌗 Incognito Theme Toggle
 - 🖤 Plain Backgrounds in Incognito Mode
 - ✨ Animated Gallery Cards
+- 🗂 Tag Explorer modal for browsing all tags
+- 🆕 Modern responsive layout with sticky navigation
 
 ## 🚀 Use
 

--- a/index.html
+++ b/index.html
@@ -16,8 +16,11 @@
   
   <!-- Main application header -->
   <header role="banner">
-    <h1 class="visually-hidden">Artist Explorer</h1>
-    
+    <div class="top-bar">
+      <h1 class="brand">Kink Artist Explorer</h1>
+      <button id="open-tag-explorer" type="button" class="browse-btn">Browse Tags</button>
+    </div>
+
     <!-- Tag filtering controls -->
     <nav role="navigation" aria-label="Tag filters">
       <div id="tag-filter">
@@ -43,6 +46,7 @@
             <option value="name">Sort: Name</option>
             <option value="count">Sort: Total Images</option>
           </select>
+
         </div>
         
         <div id="tag-buttons" role="group" aria-label="Available tags"></div>

--- a/main.js
+++ b/main.js
@@ -33,6 +33,7 @@ import {
   setupInfiniteScroll,
   setupBackgroundRotation,
 } from "./modules/ui.js";
+import { openTagExplorer, setAllArtists as setExplorerArtists } from "./modules/tag-explorer.js";
 import { loadAppData } from "./modules/api.js";
 
 /**
@@ -54,6 +55,7 @@ async function initApp() {
     setSidebarArtists(artists);
     setTagsArtists(artists);
     setGalleryArtists(artists);
+    setExplorerArtists(artists);
 
     // Set up callback dependencies
     setRenderArtistsCallback(filterArtists);
@@ -119,6 +121,7 @@ window.kexplorer = {
   setRandomBackground,
   getActiveTags,
   renderTagButtons,
+  openTagExplorer,
 };
 
 const audioToggleBtn = document.querySelector(".audio-toggle");
@@ -143,6 +146,13 @@ if (sortSelect) {
   sortSelect.addEventListener("change", (e) => {
     setSortMode(e.target.value);
     filterArtists(true);
+  });
+}
+
+const tagExplorerBtn = document.getElementById("open-tag-explorer");
+if (tagExplorerBtn) {
+  tagExplorerBtn.addEventListener("click", () => {
+    openTagExplorer();
   });
 }
 

--- a/modules/tag-explorer.js
+++ b/modules/tag-explorer.js
@@ -1,0 +1,83 @@
+import { getActiveTags, getKinkTags, toggleTag } from './tags.js';
+import { createModal } from './ui.js';
+
+let allArtists = [];
+
+function setAllArtists(artists) {
+  allArtists = Array.isArray(artists) ? artists : [];
+}
+
+function getTagCounts() {
+  const counts = {};
+  allArtists.forEach((a) => {
+    (a.kinkTags || []).forEach((t) => {
+      counts[t] = (counts[t] || 0) + 1;
+    });
+  });
+  return counts;
+}
+
+function openTagExplorer() {
+  const counts = getTagCounts();
+  const allTags = getKinkTags();
+  const active = getActiveTags();
+
+  let sortMode = 'name';
+
+  const container = document.createElement('div');
+  container.className = 'tag-explorer';
+
+  const header = document.createElement('div');
+  header.className = 'tag-explorer-header';
+
+  const title = document.createElement('h3');
+  title.textContent = 'Tags';
+  header.appendChild(title);
+
+  const sortSelect = document.createElement('select');
+  sortSelect.innerHTML = `<option value="name">Sort: Name</option><option value="count">Sort: Count</option>`;
+  sortSelect.onchange = () => {
+    sortMode = sortSelect.value;
+    renderList();
+  };
+  header.appendChild(sortSelect);
+
+  container.appendChild(header);
+
+  const list = document.createElement('div');
+  list.className = 'tag-explorer-tags';
+  container.appendChild(list);
+
+  function renderList() {
+    list.innerHTML = '';
+    const tags = allTags.slice().sort((a, b) => {
+      if (sortMode === 'count') {
+        return (counts[b] || 0) - (counts[a] || 0);
+      }
+      return a.localeCompare(b);
+    });
+    tags.forEach((tag) => {
+      const btn = document.createElement('button');
+      btn.className = 'tag-button';
+      btn.textContent = `${tag.replace(/_/g, ' ')} (${counts[tag] || 0})`;
+      if (active.has(tag)) btn.classList.add('active');
+      btn.onclick = () => {
+        toggleTag(tag);
+        if (active.has(tag)) {
+          active.delete(tag);
+          btn.classList.remove('active');
+        } else {
+          active.add(tag);
+          btn.classList.add('active');
+        }
+      };
+      list.appendChild(btn);
+    });
+  }
+
+  const modal = createModal(container, 'modal');
+  document.body.appendChild(modal);
+  renderList();
+}
+
+export { openTagExplorer, setAllArtists };

--- a/modules/tags.js
+++ b/modules/tags.js
@@ -226,6 +226,22 @@ function clearAllTags() {
 }
 
 /**
+ * Toggles a single tag on or off
+ */
+function toggleTag(tag) {
+  if (activeTags.has(tag)) {
+    activeTags.delete(tag);
+  } else {
+    activeTags.add(tag);
+    spawnBubble(tag);
+  }
+  renderTagButtons();
+  if (renderArtists) renderArtists(true);
+  if (setRandomBackground) setRandomBackground();
+  if (navigator.vibrate) navigator.vibrate(50);
+}
+
+/**
  * Handles tag search input with debouncing
  */
 function handleTagSearch(value) {
@@ -365,5 +381,6 @@ export {
   getSearchFilter,
   getArtistNameFilter,
   getKinkTags,
+  toggleTag,
   spawnBubble,
 };

--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
 /* Feminized, girly, immersive style.css - Modernized with CSS Variables */
-@import url('https://fonts.googleapis.com/css2?family=Hi+Melody&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Hi+Melody&family=Poppins:wght@400;700&display=swap');
 
 /* CSS Custom Properties (Variables) */
 :root {
@@ -43,7 +43,8 @@
   --border-radius-lg: 12px;
   
   /* Typography */
-  --font-family-primary: "Hi Melody", sans-serif;
+  --font-family-primary: "Poppins", sans-serif;
+  --font-family-heading: "Hi Melody", cursive;
   --font-size-sm: 0.875rem;
   --font-size-base: 1rem;
   --font-size-lg: 1.125rem;
@@ -177,6 +178,42 @@ html, body {
 header {
   position: relative;
   z-index: var(--z-base);
+}
+
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--spacing-md) var(--spacing-lg);
+  backdrop-filter: blur(6px);
+  background: rgba(255, 255, 255, 0.4);
+  position: sticky;
+  top: 0;
+  z-index: var(--z-floating);
+}
+
+.brand {
+  font-family: var(--font-family-heading);
+  font-size: 2rem;
+  margin: 0;
+  background: linear-gradient(90deg, var(--primary-pink), var(--dark-pink));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.browse-btn {
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-weight: bold;
+  border-radius: var(--border-radius-md);
+  border: none;
+  background: var(--accent-pink);
+  color: #fff;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.browse-btn:hover {
+  background: var(--dark-pink);
 }
 
 /* Tag filter section */
@@ -933,7 +970,7 @@ audio#moan-audio { display: none; }
   display: flex;
   flex-direction: column;
   gap: 0.6em;
-  font-family: "Fira Sans", sans-serif;
+  font-family: var(--font-family-primary);
   backdrop-filter: blur(6px);
   border: 2.5px solid #ffb6d5 !important;
 }
@@ -1522,7 +1559,7 @@ input[type="text"]:focus, input[type="search"]:focus {
   border: 2px solid #fd7bc5;
   border-radius: 2em;
   padding: 0.7em 2.5em 0.7em 1.5em;
-  font-family: "Hi Melody", sans-serif;
+  font-family: var(--font-family-heading);
   font-size: 1.1em;
   font-weight: bold;
   box-shadow: 0 2px 8px #fd7bc540;
@@ -1571,4 +1608,47 @@ input[type="text"]:focus, input[type="search"]:focus {
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+/* Modal styles for tag explorer */
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10050;
+}
+.modal-content {
+  background: var(--cream-pink);
+  color: var(--dark-pink);
+  padding: var(--spacing-lg);
+  border-radius: var(--border-radius-lg);
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: var(--shadow-lg);
+}
+
+.tag-explorer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  min-width: 260px;
+}
+.tag-explorer-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+.tag-explorer-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  justify-content: center;
+}
+.tag-explorer-tags .tag-button {
+  flex: 0 1 auto;
 }


### PR DESCRIPTION
## Summary
- add Tag Explorer modal for browsing all tags
- allow toggling tags programmatically
- redesign header with sticky top bar and modern font
- document modern responsive layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686c056508ec832c8c9b0ef3bed2d0ea