### PR TITLE
feat: cache data fetches

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,7 +19,6 @@ import {
   getArtistNameFilter,
   renderTagButtons,
   setTagSearchMode,
-  setKinkTags,
 } from "./modules/tags.js";
 import {
   initGallery,
@@ -54,8 +53,7 @@ import { createTTSToggleButton } from "./modules/tts-toggle.js";
 async function initApp() {
   try {
     // Load data files
-    const { artists, tooltips, generalTaunts, tagTaunts, kinkTags } =
-      await loadAppData();
+    const { artists, tooltips, generalTaunts, tagTaunts } = await loadAppData();
 
     // Initialize modules
     initUI();
@@ -68,7 +66,7 @@ async function initApp() {
 
     // Add TTS toggle button to audio controls
     createTTSToggleButton();
-    initTags();
+    await initTags();
     initGallery();
 
     // Set up data sharing between modules
@@ -87,8 +85,15 @@ async function initApp() {
     setTagTooltips(tooltips);
     setTagTaunts(tagTaunts);
     setTaunts(generalTaunts);
-    setKinkTags(kinkTags);
     startTauntTicker(generalTaunts, 30000);
+
+    // Use loaded tooltips to set a random tagline
+    const quotes = Object.values(tooltips).filter(Boolean);
+    if (quotes.length > 0) {
+      const random = quotes[Math.floor(Math.random() * quotes.length)];
+      const taglineElem = document.getElementById("tagline");
+      if (taglineElem) taglineElem.textContent = random;
+    }
 
     // Initial render
     renderTagButtons();
@@ -128,21 +133,7 @@ if (document.readyState === "loading") {
   initApp();
 }
 
-// Load tag-tooltips.json and set a random quote as the tagline
-fetch("tag-tooltips.json")
-  .then((res) => res.json())
-  .then((tooltips) => {
-    // tooltips is expected to be an object: { tag: "tooltip", ... }
-    const quotes = Object.values(tooltips).filter(Boolean);
-    if (quotes.length > 0) {
-      const random = quotes[Math.floor(Math.random() * quotes.length)];
-      const taglineElem = document.getElementById("tagline");
-      if (taglineElem) taglineElem.textContent = random;
-    }
-  })
-  .catch(() => {
-    // fallback: do nothing or keep default tagline
-  });
+// tag-tooltips are loaded in initApp and used for tagline
 
 // Global error handling
 window.addEventListener("error", (event) => {

--- a/modules/api.js
+++ b/modules/api.js
@@ -5,6 +5,8 @@
 // Use the global fetch implementation (available in modern browsers and Node 18+)
 const fetchFn = fetch;
 
+import { fetchWithCache } from "./fetch-cache.js";
+
 /**
  * Checks if a post has all the specified tags
  */
@@ -142,8 +144,7 @@ async function loadArtists() {
       const data = await fs.readFile(filePath, "utf8");
       artistsCache = JSON.parse(data);
     } else {
-      const response = await fetchFn("artists.json");
-      artistsCache = await response.json();
+      artistsCache = await fetchWithCache("artists.json");
     }
   } catch (e) {
     console.warn("Failed to load artists.json:", e);
@@ -207,13 +208,12 @@ function clearArtistCache(artistName) {
  */
 async function loadAppData() {
   try {
-    const [artists, tooltips, generalTaunts, tagTaunts, kinkTags] =
+    const [artists, tooltips, generalTaunts, tagTaunts] =
       await Promise.all([
-        fetchFn("artists.json").then((r) => r.json()),
-        fetchFn("tag-tooltips.json").then((r) => r.json()),
-        fetchFn("taunts.json").then((r) => r.json()),
-        fetchFn("tag-taunts.json").then((r) => r.json()),
-        fetchFn("kink-tags.json").then((r) => r.json()),
+        fetchWithCache("artists.json"),
+        fetchWithCache("tag-tooltips.json"),
+        fetchWithCache("taunts.json"),
+        fetchWithCache("tag-taunts.json"),
       ]);
 
     return {
@@ -221,7 +221,6 @@ async function loadAppData() {
       tooltips,
       generalTaunts,
       tagTaunts,
-      kinkTags,
     };
   } catch (error) {
     console.error("Failed to load required data files:", error);

--- a/modules/fetch-cache.js
+++ b/modules/fetch-cache.js
@@ -1,0 +1,63 @@
+export async function fetchWithCache(url, options = {}) {
+  const {
+    cacheKey = url,
+    useCache = true,
+    type = 'json',
+    placeholder = 'fallback.jpg'
+  } = options;
+
+  const isBrowser = typeof window !== 'undefined';
+  const storage = isBrowser ? window.localStorage : null;
+  const memoryCache = fetchWithCache._cache || (fetchWithCache._cache = {});
+
+  if (useCache) {
+    if (isBrowser && storage) {
+      const cached = storage.getItem(cacheKey);
+      if (cached) {
+        try {
+          return JSON.parse(cached);
+        } catch {
+          storage.removeItem(cacheKey);
+        }
+      }
+    } else if (memoryCache[cacheKey]) {
+      return memoryCache[cacheKey];
+    }
+  }
+
+  try {
+    let data;
+    if (isBrowser || url.startsWith('http')) {
+      const resp = await fetch(url);
+      if (!resp.ok) throw new Error(`status ${resp.status}`);
+      data = type === 'json' ? await resp.json() : await resp.blob();
+    } else {
+      const fs = await import('fs/promises');
+      const { fileURLToPath } = await import('url');
+      const { dirname, resolve } = await import('path');
+      const __filename = fileURLToPath(import.meta.url);
+      const __dirname = dirname(__filename);
+      const filePath = resolve(__dirname, '..', url);
+      const fileData = await fs.readFile(filePath, 'utf8');
+      data = JSON.parse(fileData);
+    }
+
+    if (useCache) {
+      if (isBrowser && storage && type === 'json') {
+        storage.setItem(cacheKey, JSON.stringify(data));
+      } else {
+        memoryCache[cacheKey] = data;
+      }
+    }
+    return data;
+  } catch (err) {
+    console.warn(`fetchWithCache failed for ${url}:`, err);
+    if (type === 'image') {
+      return placeholder;
+    }
+    if (isBrowser) {
+      alert(`Failed to fetch ${url}`);
+    }
+    return null;
+  }
+}

--- a/modules/tags.js
+++ b/modules/tags.js
@@ -1,4 +1,5 @@
 import { vibrate } from "./ui.js";
+import { fetchWithCache } from "./fetch-cache.js";
 
 /**
  * Tags module - Handles tag filtering, buttons, and related functionality
@@ -362,7 +363,7 @@ function handleArtistNameFilter(value) {
 /**
  * Initializes the tags module with DOM elements and event listeners
  */
-function initTags() {
+async function initTags() {
   // Get DOM references
   tagButtonsContainer = document.getElementById("tag-buttons");
   tagSearchInput = document.getElementById("tag-search");
@@ -394,6 +395,12 @@ function initTags() {
     artistNameFilterInput.addEventListener("input", (e) => {
       handleArtistNameFilter(e.target.value);
     });
+  }
+
+  // Load kink tags from file
+  const loadedTags = await fetchWithCache("kink-tags.json");
+  if (Array.isArray(loadedTags)) {
+    setKinkTags(loadedTags);
   }
 }
 


### PR DESCRIPTION
## Summary
- add shared `fetchWithCache` helper that persists JSON results in localStorage
- use helper to load app data and artists, dropping redundant `kink-tags` load from api
- have `tags` module fetch `kink-tags.json` itself and use cached tagline data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2e7f5af98832c9e1064ee496575e3