### PR TITLE
Ensure tag counts reflect unique artists

### DIFF
--- a/modules/tag-explorer.js
+++ b/modules/tag-explorer.js
@@ -63,11 +63,17 @@ function getFilteredCounts(active) {
     return lastCountsCache;
   }
   const counts = {};
+  const countedArtists = {};
   const filtered = getFilteredArtists(active);
   filtered.forEach((a) => {
+    const artistName = a.artistName;
     const tags = Array.isArray(a.kinkTags) ? a.kinkTags : [];
     tags.forEach((t) => {
-      counts[t] = (counts[t] || 0) + 1;
+      if (!countedArtists[t]) countedArtists[t] = new Set();
+      if (!countedArtists[t].has(artistName)) {
+        countedArtists[t].add(artistName);
+        counts[t] = (counts[t] || 0) + 1;
+      }
     });
   });
   lastCountsCache = counts;


### PR DESCRIPTION
## Summary
- avoid double-counting artists when aggregating tag counts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2ebcce9f0832c850c765996243161