### PR TITLE
feat: add collapsible categorized tag toolbar

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,3 +1,22 @@
 import App from './src/App.js';
+import { loadAppData } from './modules/api.js';
+import { setTagTooltips, setTagTaunts, setTaunts } from './modules/tags.js';
+import { setAllArtists as setGalleryArtists, filterArtists } from './modules/gallery.js';
+import { setAllArtists as setExplorerArtists } from './modules/tag-explorer.js';
+import { setAllArtists as setSidebarArtists } from './modules/sidebar.js';
 const { createApp } = Vue;
-createApp(App).mount('#app');
+
+loadAppData()
+  .then(({ artists, tooltips, generalTaunts, tagTaunts }) => {
+    setGalleryArtists(artists);
+    setExplorerArtists(artists);
+    setSidebarArtists(artists);
+    setTagTooltips(tooltips);
+    setTagTaunts(tagTaunts);
+    setTaunts(generalTaunts);
+    createApp(App).mount('#app');
+    filterArtists();
+  })
+  .catch(() => {
+    createApp(App).mount('#app');
+  });

--- a/style.css
+++ b/style.css
@@ -766,6 +766,14 @@ body > nav,
 }
 
 /* Filter UI */
+.filter-bar {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: rgba(255, 240, 250, 0.95);
+  box-shadow: 0 2px 8px rgba(253, 123, 197, 0.15);
+}
+
 .filter-toggle {
   background: var(--accent1);
   border: none;
@@ -779,7 +787,7 @@ body > nav,
   padding: var(--padding);
 }
 
-.filter-bar.collapsed {
+.filter-bar.collapsed #tag-filter {
   display: none;
 }
 


### PR DESCRIPTION
## Summary
- add hand-picked tag categories and collapsible toolbar
- load app data before mounting to render artist gallery
- style filter bar as sticky top row with sissy colors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4381b9928832ca21d6c0e0c2bfc1c