### PR TITLE
Fix card layout and center viewer

### DIFF
--- a/modules/gallery.js
+++ b/modules/gallery.js
@@ -921,6 +921,10 @@ function renderArtistCards(artists, selectedTagsOverride) {
       taglist.style.display = taglist.style.display === "none" ? "block" : "none";
     });
 
+    const actions = document.createElement("div");
+    actions.className = "card-actions";
+    actions.append(copyBtn, reloadBtn, tagToggleBtn);
+
     // Add humiliation overlay on hover
     card.addEventListener("mouseenter", () => {
       let overlay = card.querySelector(".gallery-humiliation-overlay");
@@ -945,7 +949,7 @@ function renderArtistCards(artists, selectedTagsOverride) {
       }
     });
 
-    card.append(img, name, taglist, tagCountDiv, copyBtn, reloadBtn, tagToggleBtn);
+    card.append(img, name, taglist, tagCountDiv, actions);
     frag.appendChild(card);
   });
   artistGallery.appendChild(frag);

--- a/style.css
+++ b/style.css
@@ -283,10 +283,7 @@ body > nav,
 .joi-modal,
 .taunt-modal {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
+  inset: 0;
   background: rgba(255, 240, 250, 1);
   backdrop-filter: blur(2.5px) saturate(1.1);
   display: flex;
@@ -736,9 +733,9 @@ body > nav,
 
 /* Mobile refinement */
 @media (max-width: 700px) {
-  .fullscreen-wrapper .zoom-content { max-width: 100vw !important; }
-  .fullscreen-wrapper .zoom-content .zoom-prev,
-  .fullscreen-wrapper .zoom-content .zoom-next { flex: 0 0 46px !important; width: 46px !important; min-width:46px !important; font-size: 1.9rem !important; }
+.fullscreen-wrapper .zoom-content { max-width: 100vw !important; }
+.fullscreen-wrapper .zoom-content .zoom-prev,
+.fullscreen-wrapper .zoom-content .zoom-next { flex: 0 0 46px !important; width: 46px !important; min-width:46px !important; font-size: 1.9rem !important; }
 }
 
 /* Tag explorer specifics */
@@ -1421,4 +1418,30 @@ html.tag-explorer-open {
 .copied-sidebar-close:hover { background: #ffd6f6; }
 .zoom-close:focus-visible,
 .copied-sidebar-close:focus-visible { outline: 3px solid #fd7bc5; outline-offset:2px; }
+
+#artist-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  width: 100%;
+}
+
+.artist-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.artist-tags {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  margin-bottom: 0.5em;
+}
+
+.card-actions {
+  margin-top: auto;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.4em;
+}
 


### PR DESCRIPTION
## Summary
- keep artist card buttons visible by moving them into a flex container
- make artist gallery responsive and avoid overflow
- center fullscreen viewer with fixed inset layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3afcb084c832c8d144d252487f85d