### PR TITLE
Fix artist gallery infinite scroll and pink styling

### DIFF
--- a/modules/api.js
+++ b/modules/api.js
@@ -255,10 +255,12 @@ async function fetchAllArtistImages(
 ) {
   const MAX_PAGES = options.maxPages || 40; // 40 pages x 200 = 8000 max
   const LIMIT = 200;
+  const ORDER = options.order || "approvals";
   // First, fetch the first page to get total count
   const firstPage = await fetchArtistImages(artistName, selectedTags, {
     limit: LIMIT,
     page: 1,
+    order: ORDER,
   });
   if (!firstPage || firstPage.length === 0) return [];
   // Estimate total pages
@@ -276,7 +278,11 @@ async function fetchAllArtistImages(
   const pagePromises = [];
   for (let page = 2; page <= totalPages; page++) {
     pagePromises.push(
-      fetchArtistImages(artistName, selectedTags, { limit: LIMIT, page })
+      fetchArtistImages(artistName, selectedTags, {
+        limit: LIMIT,
+        page,
+        order: ORDER,
+      })
     );
   }
   const restPages = await Promise.all(pagePromises);

--- a/modules/gallery.js
+++ b/modules/gallery.js
@@ -296,8 +296,8 @@ async function openArtistZoom(artist) {
   let grid, zoomContent, backBtn;
   let posts = [];
   let page = 1;
+  let totalPages = Infinity;
   let loading = false;
-  let hasMore = true;
   let currentIndex = 0;
 
   function returnToGrid() {
@@ -311,7 +311,7 @@ async function openArtistZoom(artist) {
   zoomContent = wrapper.querySelector(".zoom-content");
 
   backBtn = document.createElement("button");
-  backBtn.className = "zoom-back";
+  backBtn.className = "zoom-back-btn";
   backBtn.textContent = "Back";
   backBtn.addEventListener("click", returnToGrid);
   zoomContent.appendChild(backBtn);
@@ -326,25 +326,40 @@ async function openArtistZoom(artist) {
   grid.style.overflowY = "auto";
   wrapper.appendChild(grid);
 
+  const sentinel = document.createElement("div");
+  sentinel.id = "grid-sentinel";
+  grid.appendChild(sentinel);
+
   zoomContent.style.display = "none";
 
   document.body.appendChild(wrapper);
   wrapper.focus();
 
   async function loadPage() {
-    if (loading || !hasMore) return;
+    if (loading || page > totalPages) return;
     loading = true;
     try {
       const api = await import("./api.js");
-      const newPosts = await api.fetchArtistImages(artist.artistName, [], { limit: 40, page });
+      if (page === 1) {
+        try {
+          const count = await api.getArtistImageCount(artist.artistName);
+          totalPages = Math.max(1, Math.ceil(count / 40));
+        } catch {
+          totalPages = Infinity;
+        }
+      }
+      const newPosts = await api.fetchArtistImages(artist.artistName, [], {
+        limit: 40,
+        page,
+        order: "approvals",
+      });
       if (!Array.isArray(newPosts) || newPosts.length === 0) {
-        hasMore = false;
+        totalPages = page - 1;
         return;
       }
       const start = posts.length;
       posts = posts.concat(newPosts);
       renderThumbs(newPosts, start);
-      if (newPosts.length < 40) hasMore = false;
       page++;
     } finally {
       loading = false;
@@ -367,21 +382,22 @@ async function openArtistZoom(artist) {
         currentIndex = index;
         showZoom(index);
       });
-      grid.appendChild(thumb);
+      grid.insertBefore(thumb, sentinel);
     });
   }
 
-  let thumbTicking = false;
-  grid.addEventListener("scroll", () => {
-    if (thumbTicking) return;
-    thumbTicking = true;
-    requestAnimationFrame(() => {
-      thumbTicking = false;
-      if (grid.scrollTop + grid.clientHeight >= grid.scrollHeight - 100) {
-        loadPage();
-      }
-    });
-  }, { passive: true });
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          loadPage();
+        }
+      });
+    },
+    { root: grid, rootMargin: "0px", threshold: 0.1 }
+  );
+
+  observer.observe(sentinel);
 
   function showZoom(index) {
     grid.style.display = "none";
@@ -427,7 +443,7 @@ async function openArtistZoom(artist) {
   });
 
   nextBtn.addEventListener("click", async () => {
-    if (currentIndex === posts.length - 1 && hasMore) {
+    if (currentIndex === posts.length - 1 && page <= totalPages) {
       await loadPage();
     }
     if (currentIndex < posts.length - 1) {

--- a/style.css
+++ b/style.css
@@ -734,7 +734,7 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
   max-width: 95%;
   margin-left: auto;
   margin-right: auto;
-  background: none;
+  background: #ffe6f2;
 }
 
 @supports (-moz-appearance: none) {
@@ -750,7 +750,7 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
   border-radius: 0.7em;
   margin-bottom: 0.1em;
   box-shadow: 0 2px 8px #fd7bc540;
-  background: #fff8fc;
+  background: #fff0f8;
   display: block;
   margin-left: auto;
   margin-right: auto;
@@ -804,6 +804,13 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
     justify-content: center;
     gap: 1em;
     margin-top: 0.5em;
+}
+
+.zoom-toolbar {
+  display: flex;
+  justify-content: center;
+  gap: 0.5em;
+  margin-top: 0.5em;
 }
 
 .zoom-back-btn {


### PR DESCRIPTION
## Summary
- ensure `fetchAllArtistImages` honors order parameter
- rework artist zoom viewer to load all pages via IntersectionObserver-driven infinite scroll
- apply pink styling to thumbnail grid and toolbar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c60fef1168832c812cb749208c7e9b