### PR TITLE
refactor: move pink bar styles into Tailwind

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,14 +16,14 @@
   
   <!-- Main application header -->
   <header role="banner">
-    <div class="container">
-      <div class="top-bar">
+    <div class="mx-auto max-w-screen-lg">
+      <div id="top-bar" class="flex items-center justify-center gap-3 w-full px-4 py-2 text-pink-800 text-[1.04em] font-semibold bg-pink-gradient shadow-card border-b-2 border-pink-500/40 rounded-b-card sticky top-0 left-0 z-[10000]">
         <h1 class="brand">Artist Explorer</h1>
         <div class="brand-sissy">✧ Welcome cutie. ✧<br>Obey, drool, and discover your next obsession~</div>
         <span class="tagline" id="tagline">Pathetic..~</span>
       </div>
       <!-- New compact tag explorer bar -->
-      <div class="tag-explorer-bar" id="tag-explorer-bar">
+      <div id="tag-explorer-bar" class="flex items-center justify-center gap-3 w-full px-4 py-2 text-pink-800 text-[1.04em] font-semibold bg-pink-gradient shadow-card border-b-2 border-pink-500/40 rounded-b-card sticky left-0" style="top: var(--tagbar-top);">
         <button class="bar-btn" id="prompts-btn">Prompts</button>
         <button class="bar-btn" id="filters-btn" aria-expanded="false" aria-controls="filter-controls">Filters</button>
       </div>
@@ -31,7 +31,7 @@
   </header>
 
   <!-- Main content area -->
-  <main role="main" class="container">
+  <main role="main" class="mx-auto max-w-screen-lg">
     <!-- Tag filtering controls -->
     <section id="filter-controls" class="filter-controls" aria-label="Tag filters" aria-hidden="true">
       <div class="filter-inputs">
@@ -44,7 +44,7 @@
 
 
     <!-- Selected tags bar -->
-    <section id="selected-tags" class="selected-tags-bar" aria-label="Selected tags"></section>
+    <section id="selected-tags" aria-label="Selected tags" class="flex flex-wrap gap-2 w-full px-4 py-2 text-pink-800 text-[1.04em] font-semibold bg-pink-gradient shadow-card border-b-2 border-pink-500/40 rounded-b-card" style="display:none;"></section>
 
     <!-- Filter results summary -->
     <section id="filtered-results" aria-live="polite" aria-label="Search results summary"></section>

--- a/modules/tag-explorer.js
+++ b/modules/tag-explorer.js
@@ -98,12 +98,13 @@ function openTagExplorer() {
 
 
   // Selected tags bar (global, outside modal)
-  let selectedTagsBar = document.querySelector('.selected-tags-bar');
+  let selectedTagsBar = document.getElementById('selected-tags');
   if (!selectedTagsBar) {
     selectedTagsBar = document.createElement('div');
-    selectedTagsBar.className = 'selected-tags-bar';
-    // Insert after .tag-explorer-bar if present
-    const topBar = document.querySelector('.tag-explorer-bar, #tag-explorer-bar');
+    selectedTagsBar.id = 'selected-tags';
+    selectedTagsBar.className = 'flex flex-wrap gap-2 w-full px-4 py-2 text-pink-800 text-[1.04em] font-semibold bg-pink-gradient shadow-card border-b-2 border-pink-500/40 rounded-b-card';
+    // Insert after tag explorer bar if present
+    const topBar = document.getElementById('tag-explorer-bar');
     if (topBar && topBar.parentNode) {
       topBar.parentNode.insertBefore(selectedTagsBar, topBar.nextSibling);
     } else {

--- a/src/main.js
+++ b/src/main.js
@@ -329,7 +329,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
   // Make tag-explorer-bar fixed on scroll with proper offset below top-bar
   const tagBar = document.getElementById("tag-explorer-bar");
-  const topBarEl = document.querySelector(".top-bar");
+  const topBarEl = document.getElementById("top-bar");
 
   function setTagBarTop(useTopBarOffset) {
     const topOffset = topBarEl ? (topBarEl.offsetHeight + 8) : 8;

--- a/src/style.css
+++ b/src/style.css
@@ -3,23 +3,9 @@
 @tailwind utilities;
 
 /* Tag Explorer - Modern Unified Theme (2025) */
-/* Core palette */
-:root {
-  --accent1: #d63384;
-  --accent2: #ff69b4;
-  --border-color: #d63384;
-  --radius: 14px;
-  --btn-font: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  --padding: 5px;
-  --gradient-bg: linear-gradient(120deg, rgba(255,214,246,0.82) 60%, rgba(253,123,197,0.92) 100%);
-  --gradient-bg-mobile: linear-gradient(120deg, rgba(255,214,246,0.92) 60%, rgba(253,123,197,0.98) 100%);
-  --shadow: 0 2px 16px rgba(214,51,132,0.15), 0 1.5px 8px rgba(255,105,180,0.10);
-  background: #1f0f1f;
-  color: #e6e6e6;
-}
 
 body {
-  font-family: var(--btn-font);
+  font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   background: #1f0f1f;
   color: #e6e6e6;
   margin: 0;
@@ -46,102 +32,19 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
   z-index: 1;
 }
 
-/* --- Unified Glossy Bar & Sidebar Styles --- */
-.top-bar, .tag-explorer-bar, #tag-explorer-bar, .selected-tags-bar, .sidebar {
-  background: var(--gradient-bg) !important;
-  backdrop-filter: blur(12px) saturate(1.12) !important;
-  border-radius: 0 0 1.1em 1.1em !important;
-  box-shadow: var(--shadow) !important;
-  border: 2.5px solid var(--accent1)40 !important;
-  border-top: none !important;
-  position: relative;
-  overflow: visible;
-}
-
-/* Foldable devices (e.g., Galaxy Fold 4) */
-@media (max-width: 600px) {
-  .top-bar, .tag-explorer-bar, #tag-explorer-bar, .selected-tags-bar {
-    flex-wrap: wrap;
-  }
-}
-@media (max-width: 700px) {
-  .top-bar, .tag-explorer-bar, #tag-explorer-bar, .selected-tags-bar, .sidebar {
-    background: var(--gradient-bg-mobile) !important;
-    backdrop-filter: blur(14px) saturate(1.13) !important;
-    border-radius: 0 0 0.7em 0.7em !important;
-    box-shadow: var(--shadow) !important;
-    border: 2.5px solid var(--accent1)40 !important;
-    border-top: none !important;
-    position: relative;
-    overflow: visible;
-  }
-}
-
-.top-bar, .tag-explorer-bar, #tag-explorer-bar, .selected-tags-bar {
-  width: 100%;
-  max-width: 100vw;
-  margin: 0 auto 0.2em auto;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.7em;
-  padding: 0.4em 1.1em 0.3em 1.1em;
-  z-index: 10000;
-  font-size: 1.04em;
-  font-family: var(--btn-font);
-
-  font-weight: 600;
-  color: var(--accent1);
-  letter-spacing: 0.01em;
-  box-sizing: border-box;
-  min-height: 2.2em;
-  overflow-x: auto;
-  position: sticky;
-  top: 0;
-  left: 0;
-  background: var(--gradient-bg) !important;
-  transition: box-shadow 0.18s, background 0.18s, top 0.28s cubic-bezier(0.4,0,0.2,1), opacity 0.28s cubic-bezier(0.4,0,0.2,1);
-  text-align: center;
-}
-
-/* Selected tags display */
-.selected-tags-bar {
-  display: none;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-}
-
+/* Selected tag pills */
 .selected-tag {
-  background: var(--accent1);
+  background: #d63384;
   color: #fff;
   border: none;
-  border-radius: var(--radius);
+  border-radius: 2px;
   padding: 0.2em 0.6em;
   font-size: 0.9em;
   cursor: pointer;
 }
 
 .selected-tag:hover {
-  background: var(--accent2);
-}
-
-.sidebar {
-  min-width: 220px;
-  max-width: 340px;
-  color: var(--accent1);
-  font-size: 1em;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  transition: background 0.2s, box-shadow 0.2s;
-  overflow-y: auto;
-  padding: 1.1em 1.1em 1.1em 1.1em;
-  margin: 0;
-  position: sticky;
-  top: 3.1em;
-  left: 0;
-  transition: box-shadow 0.18s, background 0.18s, top 0.28s cubic-bezier(0.4,0,0.2,1), opacity 0.28s cubic-bezier(0.4,0,0.2,1);
-  min-height: 2.2em;
+  background: #ff69b4;
 }
 
 .sidebar-wrapper {
@@ -226,7 +129,7 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
 #audio-panel .audio-controls button {
   background: none;
   border: none;
-  color: var(--accent1);
+  color: #d63384;
   font-size: 0.98em;
   margin: 0 0.15em;
   cursor: pointer;
@@ -247,7 +150,7 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
   bottom: 100%;
   transform: translateX(-50%) translateY(-0.7em);
   background: linear-gradient(120deg, #fff8fc 60%, #ffd6f6 100%);
-  color: var(--accent1);
+  color: #d63384;
   border: 2.5px solid #fd7bc5;
   border-radius: 1.2em;
   box-shadow: 0 2px 16px rgba(253,123,197,0.13);
@@ -340,10 +243,10 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
 }
 
 /* --- Button Styles: Rectangular Lace, Modern --- */
-.copy-button, .browse-btn, .tag-btn, .tag-button, .reload-button, .zoom-tool, #back-to-top, .sidebar-toggle, .audio-toggle, .theme-toggle, #moan-mute, #audio-prev, #audio-next, #audio-play, #audio-toggle, .tag-explorer-bar button, #tag-explorer-bar button, .sidebar-btn, .tts-toggle-btn, .artist-card .copy-btn, .bar-btn {
+.copy-button, .browse-btn, .tag-btn, .tag-button, .reload-button, .zoom-tool, #back-to-top, .sidebar-toggle, .audio-toggle, .theme-toggle, #moan-mute, #audio-prev, #audio-next, #audio-play, #audio-toggle, #tag-explorer-bar button, .sidebar-btn, .tts-toggle-btn, .artist-card .copy-btn, .bar-btn {
   background: repeating-linear-gradient(135deg, #fff8fc 0 14px, #f8e6ff 14px 28px), url('data:image/svg+xml;utf8,<svg width="100%25" height="100%25" xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="100%25" height="100%25" fill="none" stroke="%23fd7bc5" stroke-width="3" stroke-dasharray="7,7"/><rect x="7" y="7" width="calc(100%25 - 14px)" height="calc(100%25 - 14px)" fill="none" stroke="%23e0c6e6" stroke-width="2" stroke-dasharray="2,5"/></svg>');
   background-blend-mode: lighten;
-  color: var(--accent1);
+  color: #d63384;
   border: none;
   border-radius: 0;
   box-shadow: 0 0 0 4px #f8e6ff inset;
@@ -363,13 +266,13 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
   min-width: 2.5em;
   min-height: 2.2em;
 }
-.copy-button:hover, .browse-btn:hover, .tag-btn:hover, .tag-button:hover, .reload-button:hover, .zoom-tool:hover, #back-to-top:hover, .sidebar-toggle:hover, .audio-toggle:hover, .theme-toggle:hover, #moan-mute:hover, #audio-prev:hover, #audio-next:hover, #audio-play:hover, #audio-toggle:hover, .tag-explorer-bar button:hover, #tag-explorer-bar button:hover, .sidebar-btn:hover, .tts-toggle-btn:hover, .artist-card .copy-btn:hover, .bar-btn:hover, .copy-button:focus, .browse-btn:focus, .tag-btn:focus, .tag-button:focus, .reload-button:focus, .zoom-tool:focus, #back-to-top:focus, .sidebar-toggle:focus, .audio-toggle:focus, .theme-toggle:focus, #moan-mute:focus, #audio-prev:focus, #audio-next:focus, #audio-play:focus, #audio-toggle:focus, .tag-explorer-bar button:focus, #tag-explorer-bar button:focus, .sidebar-btn:focus, .tts-toggle-btn:focus, .artist-card .copy-btn:focus, .bar-btn:focus {
+.copy-button:hover, .browse-btn:hover, .tag-btn:hover, .tag-button:hover, .reload-button:hover, .zoom-tool:hover, #back-to-top:hover, .sidebar-toggle:hover, .audio-toggle:hover, .theme-toggle:hover, #moan-mute:hover, #audio-prev:hover, #audio-next:hover, #audio-play:hover, #audio-toggle:hover, #tag-explorer-bar button:hover, .sidebar-btn:hover, .tts-toggle-btn:hover, .artist-card .copy-btn:hover, .bar-btn:hover, .copy-button:focus, .browse-btn:focus, .tag-btn:focus, .tag-button:focus, .reload-button:focus, .zoom-tool:focus, #back-to-top:focus, .sidebar-toggle:focus, .audio-toggle:focus, .theme-toggle:focus, #moan-mute:focus, #audio-prev:focus, #audio-next:focus, #audio-play:focus, #audio-toggle:focus, #tag-explorer-bar button:focus, .sidebar-btn:focus, .tts-toggle-btn:focus, .artist-card .copy-btn:focus, .bar-btn:focus {
   background: linear-gradient(135deg, #f8e6ff 60%, #fd7bc5 100%), url('data:image/svg+xml;utf8,<svg width="100%25" height="100%25" xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="100%25" height="100%25" fill="none" stroke="%23b97fc9" stroke-width="3" stroke-dasharray="7,7"/><rect x="7" y="7" width="calc(100%25 - 14px)" height="calc(100%25 - 14px)" fill="none" stroke="%23fd7bc5" stroke-width="2" stroke-dasharray="2,5"/></svg>');
   color: #fff;
   box-shadow: 0 0 0 8px #fd7bc5 inset;
   text-shadow: 0 2px 8px #b97fc9, 0 0 8px #fff;
 }
-.copy-button:active, .browse-btn:active, .tag-btn:active, .tag-button:active, .reload-button:active, .zoom-tool:active, #back-to-top:active, .sidebar-toggle:active, .audio-toggle:active, .theme-toggle:active, #moan-mute:active, #audio-prev:active, #audio-next:active, #audio-play:active, #audio-toggle:active, .tag-explorer-bar button:active, #tag-explorer-bar button:active, .sidebar-btn:active, .tts-toggle-btn:active, .artist-card .copy-btn:active, .bar-btn:active {
+.copy-button:active, .browse-btn:active, .tag-btn:active, .tag-button:active, .reload-button:active, .zoom-tool:active, #back-to-top:active, .sidebar-toggle:active, .audio-toggle:active, .theme-toggle:active, #moan-mute:active, #audio-prev:active, #audio-next:active, #audio-play:active, #audio-toggle:active, #tag-explorer-bar button:active, .sidebar-btn:active, .tts-toggle-btn:active, .artist-card .copy-btn:active, .bar-btn:active {
   background: #fd7bc5;
   color: #fff;
   box-shadow: 0 2px 8px 0 rgba(120, 60, 180, 0.13), 0 0 0 4px #fd7bc5 inset;
@@ -439,14 +342,14 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
   max-height: 10vh;
   padding: 0.4em 0.7em 0.7em 0.7em;
   font-size: 0.98em;
-  font-family: var(--btn-font);
+  font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   font-weight: 600;
-  color: var(--accent1);
+  color: #d63384;
 }
 .artist-name {
   font-size: 1.1em;
   font-weight: 700;
-  color: var(--accent1);
+  color: #d63384;
   margin-bottom: 0.4em;
 }
 .artist-actions {
@@ -458,7 +361,7 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
 .tags-toggle {
   background: none;
   border: none;
-  color: var(--accent1);
+  color: #d63384;
   font-size: 1.1em;
   cursor: pointer;
   margin-left: 0.3em;
@@ -481,7 +384,7 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
 }
 .gallery-tag, .zoom-tag-pill {
   background: linear-gradient(90deg, #ffd6f6 0%, #fd7bc5 100%);
-  color: var(--accent1);
+  color: #d63384;
   padding: 0.18em 0.7em;
   font-size: 0.6em;
   font-weight: 600;
@@ -553,7 +456,7 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
 .tag-explorer-header h3 {
     font-size: 1.4em;
     font-weight: 700;
-    color: var(--accent1);
+    color: #d63384;
     text-align: center;
     margin: 0 0 0.5em 0;
 }
@@ -564,7 +467,7 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
     border-radius: 8px;
     border: 1px solid #fd7bc5;
     background: white;
-    color: var(--accent1);
+    color: #d63384;
     font-size: 1em;
     box-sizing: border-box;
 }
@@ -595,7 +498,7 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
   border-radius: 8px;
   border: 1px solid #fd7bc5;
   background: white;
-  color: var(--accent1);
+  color: #d63384;
   font-size: 1em;
 }
 
@@ -620,9 +523,9 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
 .tag-button {
   background: linear-gradient(90deg, #ffd6f6 0%, #fd7bc5 100%) !important;
   border: 1px solid #fd7bc5 !important;
-  color: var(--accent1) !important;
+  color: #d63384 !important;
   box-shadow: 0 1px 4px #fd7bc540 !important;
-  font-family: var(--btn-font);
+  font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -648,7 +551,7 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
 }
 .tag-button:focus {
   background: #fff8fc !important;
-  color: var(--accent1) !important;
+  color: #d63384 !important;
   outline: 2.5px solid #fd7bc5 !important;
   outline-offset: 2px;
 }
@@ -658,7 +561,7 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
 .tag-group-header {
   font-size: 1.18em;
   font-weight: 700;
-  color: var(--accent1);
+  color: #d63384;
   background: linear-gradient(90deg, #ffd6f6 0%, #fd7bc5 100%);
   padding: 0.7em 1.1em;
   border-radius: 1em;
@@ -785,7 +688,7 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
 .zoom-tag-pill {
   background: repeating-linear-gradient(135deg, #fff8fc 0 14px, #f8e6ff 14px 28px), url('data:image/svg+xml;utf8,<svg width="100%25" height="100%25" xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="100%25" height="100%25" fill="none" stroke="%23fd7bc5" stroke-width="2" stroke-dasharray="7,7"/><rect x="5" y="5" width="calc(100%25 - 10px)" height="calc(100%25 - 10px)" fill="none" stroke="%23e0c6e6" stroke-width="1.5" stroke-dasharray="2,5"/></svg>');
   background-blend-mode: lighten;
-  color: var(--accent1);
+  color: #d63384;
   border: none;
   border-radius: 0.7em;
   box-shadow: 0 0 0 2px #f8e6ff inset;
@@ -827,7 +730,7 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
 
 .zoom-back-btn {
   background: linear-gradient(90deg, #ffd6f6 0%, #fd7bc5 100%);
-  color: var(--accent1);
+  color: #d63384;
   border: none;
   border-radius: 1em;
   box-shadow: 0 2px 8px #fd7bc540;
@@ -865,7 +768,7 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
   position: fixed;
   background: repeating-linear-gradient(135deg, #fff8fc 0 14px, #f8e6ff 14px 28px), url('data:image/svg+xml;utf8,<svg width="100%25" height="100%25" xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="100%25" height="100%25" fill="none" stroke="%23fd7bc5" stroke-width="3" stroke-dasharray="7,7"/><rect x="7" y="7" width="calc(100%25 - 14px)" height="calc(100%25 - 14px)" fill="none" stroke="%23e0c6e6" stroke-width="2" stroke-dasharray="2,5"/></svg>');
   background-blend-mode: lighten;
-  color: var(--accent1);
+  color: #d63384;
   border: none;
   border-radius: 50%;
   box-shadow: 0 0 0 4px #f8e6ff inset;
@@ -961,7 +864,7 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
   flex-wrap: wrap;
   background: #ffd6f6;
   border: none;
-  color: var(--accent1);
+  color: #d63384;
   padding: 0.28em 0.9em;
   border-radius: 7px;
   font-family: 'Inter', sans-serif;

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,10 +1,21 @@
 const colors = require('tailwindcss/colors');
+
 module.exports = {
-  content: ['./index.html', './src/**/*.{js,ts}'],
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}', './modules/**/*.js'],
   theme: {
     extend: {
       colors: {
         primary: colors.pink,
+      },
+      backgroundImage: {
+        'pink-gradient':
+          'linear-gradient(120deg, rgba(255,214,246,0.82) 60%, rgba(253,123,197,0.92) 100%)',
+      },
+      borderRadius: {
+        card: '2px',
+      },
+      boxShadow: {
+        card: '0 2px 16px rgba(214,51,132,0.15), 0 1.5px 8px rgba(255,105,180,0.10)',
       },
     },
   },


### PR DESCRIPTION
## Summary
- add `pink-gradient`, card radius, and shared shadow to Tailwind theme
- restyle top and tag bars with Tailwind utilities and IDs
- prune redundant CSS variables and selectors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c687c5cb0c832cb5c6931aea29a0eb