### PR TITLE
Use relative asset paths and set Vite base

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <title>Artist Explorer</title>
   <meta name="description" content="Discover NSFW artists on Danbooru with kink tag filtering">
-  <link rel="stylesheet" href="/src/style.css">
+  <link rel="stylesheet" href="src/style.css">
   <link rel="icon" type="image/png" href="favicon.png">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 </head>
@@ -109,7 +109,7 @@
 
   <!-- React root and bundle -->
   <div id="app"></div>
-  <script type="module" src="/src/main.jsx"></script>
+  <script type="module" src="src/main.jsx"></script>
 </body>
 
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  base: '/tagexplorer/',
   plugins: [react()],
   test: {
     environment: 'jsdom'


### PR DESCRIPTION
## Summary
- load stylesheet and scripts via relative paths
- configure Vite to serve assets from /tagexplorer/

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c74efd89d0832cb032122723e73944