### PR TITLE
Track unfiltered post counts for pagination

### DIFF
--- a/src/components/Gallery.jsx
+++ b/src/components/Gallery.jsx
@@ -8,6 +8,7 @@ export default function Gallery() {
   const [artistIndex, setArtistIndex] = useState(0);
   const [page, setPage] = useState(1);
   const [allLoaded, setAllLoaded] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
   const [showFilters, setShowFilters] = useState(false);
   const [zoomSrc, setZoomSrc] = useState(null);
   const loaderRef = useRef(null);
@@ -23,15 +24,22 @@ export default function Gallery() {
       setAllLoaded(true);
       return;
     }
-    const posts = await fetchArtistPage(
+    const { posts, total } = await fetchArtistPage(
       currentArtist.artistName,
       selectedTags,
       page
     );
+    const more = total === 200;
+    setHasMore(more);
     if (posts.length === 0) {
+      if (more) {
+        setPage((p) => p + 1);
+        return;
+      }
       if (artistIndex + 1 < filteredArtists.length) {
         setArtistIndex((i) => i + 1);
         setPage(1);
+        setHasMore(true);
       } else {
         setAllLoaded(true);
       }
@@ -51,6 +59,7 @@ export default function Gallery() {
     setArtistIndex(0);
     setPage(1);
     setAllLoaded(false);
+    setHasMore(true);
   }, [selectedTags, artists]);
 
   useEffect(() => {

--- a/src/services/danbooru.js
+++ b/src/services/danbooru.js
@@ -1,15 +1,19 @@
-export async function fetchArtistPage(artistName, selectedTags = [], page = 1, limit = 20) {
+export async function fetchArtistPage(artistName, selectedTags = [], page = 1, limit = 200) {
   const effectiveTags = [artistName, ...selectedTags].slice(0, 2).join(' ');
   const url = `https://danbooru.donmai.us/posts.json?tags=${encodeURIComponent(effectiveTags)}+order:approvals&limit=${limit}&page=${page}`;
   try {
     const resp = await fetch(url);
     const data = await resp.json();
-    return Array.isArray(data)
-      ? data.filter(p => (p.large_file_url || p.file_url) && !p.is_banned)
-      : [];
+    if (!Array.isArray(data)) {
+      return { posts: [], total: 0 };
+    }
+    const posts = data.filter(
+      (p) => (p.large_file_url || p.file_url) && !p.is_banned
+    );
+    return { posts, total: data.length };
   } catch (e) {
     console.warn('Danbooru fetch failed', e);
-    return [];
+    return { posts: [], total: 0 };
   }
 }
 
@@ -18,10 +22,9 @@ export async function fetchAllArtistImages(artistName, selectedTags = [], option
   let page = 1;
   let all = [];
   while (true) {
-    const posts = await fetchArtistPage(artistName, selectedTags, page, limit);
-    if (!posts.length) break;
-    all = all.concat(posts);
-    if (posts.length < limit) break;
+    const { posts, total } = await fetchArtistPage(artistName, selectedTags, page, limit);
+    if (posts.length) all = all.concat(posts);
+    if (total < limit) break;
     page++;
   }
   return all;


### PR DESCRIPTION
## Summary
- Return filtered posts and original page count from `fetchArtistPage`
- Adjust `fetchAllArtistImages` to consume new page shape
- Use unfiltered totals in `Gallery` to continue pagination when filtered pages are empty

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c74efeb244832c98b29a61fef81cd1