### PR TITLE
Rebuild filter panel and restore prompt suggestions

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,24 +25,13 @@
       <!-- New compact tag explorer bar -->
       <div class="tag-explorer-bar" id="tag-explorer-bar">
         <button class="bar-btn" id="prompts-btn">Prompts</button>
-        <button class="bar-btn" id="filters-btn" aria-expanded="false" aria-controls="filter-controls">Filters</button>
+        <button class="bar-btn" id="filters-btn" aria-haspopup="dialog" aria-expanded="false" aria-controls="tag-filter-panel">Filters</button>
       </div>
     </div>
   </header>
 
   <!-- Main content area -->
   <main role="main" class="container">
-    <!-- Tag filtering controls -->
-    <section id="filter-controls" class="filter-controls" aria-label="Tag filters" aria-hidden="true">
-      <div class="filter-inputs">
-        <input id="tag-search" type="text" placeholder="Search tags" aria-label="Search tags">
-        <input id="artist-name-filter" type="text" placeholder="Filter artists by name" aria-label="Filter artists by name">
-        <button id="clear-tags" class="browse-btn">Clear Tags</button>
-      </div>
-      <div id="tag-buttons" class="tag-buttons" role="group" aria-label="Tag filters"></div>
-    </section>
-
-
     <!-- Selected tags bar -->
     <section id="selected-tags" class="selected-tags-bar" aria-label="Selected tags"></section>
 

--- a/main.js
+++ b/main.js
@@ -61,6 +61,11 @@ import { startTauntTicker } from "./modules/humiliation.js";
 
 import { renderPromptCacheUI } from "./modules/prompt-cache.js";
 import { createTTSToggleButton } from "./modules/tts-toggle.js";
+import {
+  initTagExplorer,
+  openTagExplorer,
+  setAllArtists as setExplorerArtists,
+} from "./modules/tag-explorer.js";
 
 /**
  * Initialize the application
@@ -100,6 +105,7 @@ async function initApp() {
     setSidebarArtists(artists);
     setTagsArtists(artists);
     setGalleryArtists(artists);
+    setExplorerArtists(artists);
 
     // Set up callback dependencies
     setRenderArtistsCallback(filterArtists);
@@ -124,6 +130,7 @@ async function initApp() {
     // Initial render
     renderTagButtons();
     filterArtists();
+    initTagExplorer();
 
     // Set up background rotation
     setupBackgroundRotation(setRandomBackground, 15000);
@@ -312,18 +319,19 @@ window.addEventListener("DOMContentLoaded", () => {
   // Tag Explorer Bar buttons
   const promptsBtn = document.getElementById("prompts-btn");
   const filtersBtn = document.getElementById("filters-btn");
-  const filterControls = document.getElementById("filter-controls");
 
   if (promptsBtn) {
     promptsBtn.addEventListener("click", () => {
       if (window.renderPromptCacheUI) window.renderPromptCacheUI();
     });
   }
-  if (filtersBtn && filterControls) {
+  if (filtersBtn) {
     filtersBtn.addEventListener("click", () => {
-      const open = filterControls.classList.toggle("open");
-      filtersBtn.setAttribute("aria-expanded", open);
-      filterControls.setAttribute("aria-hidden", !open);
+      openTagExplorer();
+    });
+    document.addEventListener("tagFilters:toggle", (event) => {
+      const isOpen = !!(event?.detail && event.detail.open);
+      filtersBtn.setAttribute("aria-expanded", isOpen ? "true" : "false");
     });
   }
 
@@ -366,9 +374,6 @@ window.addEventListener("DOMContentLoaded", () => {
     updateContentPad();
   });
 
-  // Remove old filter toggle logic if present
-  const filterToggle = document.getElementById("toggle-filters");
-  if (filterToggle) filterToggle.style.display = "none";
 });
 
 // Remove inline z-index overrides; CSS now controls stacking order
@@ -388,12 +393,7 @@ window.addEventListener("DOMContentLoaded", () => {
         window.renderPromptCacheUI();
       }
       if (id === 'filters-btn') {
-        const controls = document.getElementById('filter-controls');
-        if (controls) {
-          const open = controls.classList.toggle('open');
-          t.setAttribute('aria-expanded', open);
-          controls.setAttribute('aria-hidden', !open);
-        }
+        openTagExplorer();
       }
     }
   });

--- a/modules/sidebar.js
+++ b/modules/sidebar.js
@@ -452,14 +452,41 @@ function copySuggestionText() {
   if (!suggestionOutputEl) return;
   const text = suggestionOutputEl.dataset?.value || "";
   if (!text) return;
-  navigator.clipboard
-    .writeText(text)
-    .then(() => {
-      showToast("Suggested prompts copied");
-    })
-    .catch(() => {
+  if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        showToast("Suggested prompts copied");
+      })
+      .catch(() => {
+        showToast("Couldn't copy prompts");
+      });
+  } else {
+    // Fallback for environments where navigator.clipboard is not available
+    try {
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      // Prevent scrolling to bottom
+      textarea.style.position = "fixed";
+      textarea.style.top = "0";
+      textarea.style.left = "0";
+      textarea.style.width = "1px";
+      textarea.style.height = "1px";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      const successful = document.execCommand("copy");
+      document.body.removeChild(textarea);
+      if (successful) {
+        showToast("Suggested prompts copied");
+      } else {
+        showToast("Couldn't copy prompts");
+      }
+    } catch (e) {
       showToast("Couldn't copy prompts");
-    });
+    }
+  }
 }
 
 function closeSuggestionsModal() {

--- a/modules/sidebar.js
+++ b/modules/sidebar.js
@@ -5,12 +5,19 @@
 import { vibrate } from "./ui.js";
 import { getThumbnailUrl } from "./gallery.js";
 import { azureSpeak, setAzureTTSConfig, DEFAULT_VOICE } from "./azure-tts.js";
+import { getActiveTags } from "./tags.js";
 
 let copiedArtists = new Set();
 
 let copiedSidebar = null;
 let allArtists = [];
 let copiedArtistsCache = null;
+let selectedPromptArtists = new Set();
+let suggestionModal = null;
+let suggestionOutputEl = null;
+let suggestionSummaryEl = null;
+let suggestionCopyBtn = null;
+let suggestionKeyHandler = null;
 
 // TTS toggle state
 window._ttsEnabled = true;
@@ -117,6 +124,7 @@ function handleArtistCopy(artist, imgSrc) {
       if (!copiedArtists.has(artistTag)) {
         copiedArtists.add(artistTag);
         copiedArtistsCache = new Set(copiedArtists);
+        selectedPromptArtists.add(artistTag);
         updateCopiedSidebar();
         added = true;
       }
@@ -145,6 +153,16 @@ function updateCopiedSidebar() {
 
   // --- HUMILIATION: Dynamic taunt banner ---
   const copiedCount = copiedArtists.size;
+  if (copiedCount === 0) {
+    selectedPromptArtists.clear();
+  } else {
+    selectedPromptArtists = new Set(
+      [...selectedPromptArtists].filter((name) => copiedArtists.has(name))
+    );
+    if (selectedPromptArtists.size === 0) {
+      selectedPromptArtists = new Set(copiedArtists);
+    }
+  }
   let tauntMsg = "";
   if (copiedCount === 0) {
     tauntMsg = "No artists copied yet. Too shy to commit? Pathetic.";
@@ -208,58 +226,298 @@ function updateCopiedSidebar() {
   };
   copiedSection.appendChild(closeBtn);
 
-  // Copied artists list
   const copiedList = document.createElement("div");
   copiedList.className = "sidebar-copied-list";
+
+  let selectionNote = null;
+  let suggestionBtn = null;
+
   copiedArtists.forEach((artistTag, idx) => {
-    const artist = allArtists.find((a) => a.artistName.replace(/_/g, " ") === artistTag);
+    const artist = allArtists.find(
+      (a) => a.artistName && a.artistName.replace(/_/g, " ") === artistTag
+    );
     const row = document.createElement("div");
     row.className = "copied-artist-row";
-    // Thumbnail
+
+    const checkboxWrap = document.createElement("div");
+    checkboxWrap.className = "copied-artist-select-wrap";
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.className = "copied-artist-select";
+    checkbox.setAttribute(
+      "aria-label",
+      `Use ${artistTag} when suggesting prompts`
+    );
+    const isSelected = selectedPromptArtists.has(artistTag);
+    checkbox.checked = isSelected;
+    if (isSelected) row.classList.add("selected");
+    checkbox.addEventListener("change", (event) => {
+      if (event.target.checked) {
+        selectedPromptArtists.add(artistTag);
+        row.classList.add("selected");
+      } else {
+        selectedPromptArtists.delete(artistTag);
+        row.classList.remove("selected");
+      }
+      if (typeof updateSelectionSummary === "function") {
+        updateSelectionSummary();
+      }
+    });
+    checkboxWrap.appendChild(checkbox);
+    row.appendChild(checkboxWrap);
+
+    const info = document.createElement("div");
+    info.className = "copied-artist-info";
+
     if (artist) {
       let thumbUrl = artist.thumbnailUrl;
-      if (!thumbUrl && typeof getThumbnailUrl === "function") thumbUrl = getThumbnailUrl(artist);
+      if (!thumbUrl && typeof getThumbnailUrl === "function") {
+        thumbUrl = getThumbnailUrl(artist);
+      }
       if (thumbUrl) {
         const img = document.createElement("img");
         img.src = thumbUrl;
         img.className = "sidebar-thumb";
-        row.appendChild(img);
+        img.alt = `${artistTag} preview`;
+        info.appendChild(img);
       }
     }
-    // Icon
-    const icon = document.createElement("span");
-    icon.className = "sidebar-icon lipstick-kiss";
-    icon.title = "Kissed with shame!";
-    icon.innerHTML = Math.random() > 0.5 ? "💋" : "✨";
-    row.appendChild(icon);
-    // Name
+
+    const textWrap = document.createElement("div");
+    textWrap.className = "copied-artist-text";
+
     const nameSpan = document.createElement("span");
     nameSpan.textContent = artistTag;
     nameSpan.title = artist && artist.tooltip ? artist.tooltip : artistTag;
     nameSpan.className = "sidebar-artist-name";
-    row.appendChild(nameSpan);
-    // Heart for latest
+    textWrap.appendChild(nameSpan);
+
     if (idx === copiedArtists.size - 1 && copiedCount > 1) {
-      const heart = document.createElement("span");
-      heart.className = "sidebar-icon sidebar-heart";
-      heart.textContent = "💖";
-      heart.title = "Your latest obsession";
-      row.appendChild(heart);
+      const latest = document.createElement("span");
+      latest.className = "sidebar-latest-tag";
+      latest.textContent = "Latest";
+      textWrap.appendChild(latest);
     }
-    row.onclick = () => {
+
+    info.appendChild(textWrap);
+
+    const flair = document.createElement("span");
+    flair.className = "sidebar-icon lipstick-kiss";
+    flair.title = "Kissed with shame!";
+    flair.innerHTML = Math.random() > 0.5 ? "💋" : "✨";
+    info.appendChild(flair);
+
+    row.appendChild(info);
+
+    row.addEventListener("click", (event) => {
+      if (event.target && event.target.tagName === "INPUT") return;
       if (artist) {
         import("./gallery.js").then((gallery) => {
-          if (typeof gallery.openArtistZoom === "function") gallery.openArtistZoom(artist);
+          if (typeof gallery.openArtistZoom === "function") {
+            gallery.openArtistZoom(artist);
+          }
         });
       }
-    };
+    });
+
     copiedList.appendChild(row);
   });
+
+  if (copiedArtists.size === 0) {
+    const empty = document.createElement("div");
+    empty.className = "sidebar-empty";
+    empty.textContent = "Copy artists to build your queue.";
+    copiedList.appendChild(empty);
+  }
+
   copiedSection.appendChild(copiedList);
+
+  const actions = document.createElement("div");
+  actions.className = "sidebar-actions";
+  selectionNote = document.createElement("div");
+  selectionNote.className = "sidebar-selection-note";
+  actions.appendChild(selectionNote);
+
+  suggestionBtn = document.createElement("button");
+  suggestionBtn.type = "button";
+  suggestionBtn.className = "sidebar-suggest-btn";
+  suggestionBtn.textContent = "Suggest Prompts";
+  suggestionBtn.addEventListener("click", () => {
+    openSuggestionsModal();
+  });
+  actions.appendChild(suggestionBtn);
+  copiedSection.appendChild(actions);
+
+  const updateSelectionSummary = () => {
+    const validSelections = [...selectedPromptArtists].filter((name) =>
+      copiedArtists.has(name)
+    );
+    const count = validSelections.length;
+    if (selectionNote) {
+      selectionNote.textContent = count
+        ? `${count} artist${count > 1 ? "s" : ""} selected for prompts`
+        : "Select artists to tailor your prompts.";
+    }
+    if (suggestionBtn) {
+      suggestionBtn.disabled = count === 0;
+      suggestionBtn.setAttribute("aria-disabled", count === 0 ? "true" : "false");
+    }
+  };
+
+  updateSelectionSummary();
   sections.appendChild(copiedSection);
   copiedSidebar.appendChild(sections);
 
   // All sidebar style is now handled by CSS
+}
+
+function getSelectedArtistsForPrompts() {
+  const names = selectedPromptArtists.size
+    ? [...selectedPromptArtists]
+    : [...copiedArtists];
+  return names
+    .map((name) =>
+      allArtists.find(
+        (artist) =>
+          artist?.artistName && artist.artistName.replace(/_/g, " ") === name
+      )
+    )
+    .filter(Boolean);
+}
+
+function buildPromptSuggestions(selectedArtists) {
+  const active = typeof getActiveTags === "function" ? getActiveTags() : new Set();
+  const exclude = new Set(active);
+  const counts = new Map();
+
+  selectedArtists.forEach((artist) => {
+    const tags = Array.isArray(artist?.kinkTags) ? artist.kinkTags : [];
+    tags.forEach((tag) => {
+      if (exclude.has(tag)) return;
+      counts.set(tag, (counts.get(tag) || 0) + 1);
+    });
+  });
+
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 10)
+    .map(([tag]) => tag.replace(/_/g, " "));
+}
+
+function ensureSuggestionModal() {
+  if (suggestionModal && suggestionOutputEl && suggestionCopyBtn) {
+    return suggestionModal;
+  }
+  suggestionModal = document.createElement("div");
+  suggestionModal.className = "prompt-suggestion-overlay";
+  suggestionModal.setAttribute("aria-hidden", "true");
+  suggestionModal.innerHTML = `
+    <div class="prompt-suggestion" role="dialog" aria-modal="true" aria-label="Suggested prompts">
+      <header class="prompt-suggestion__header">
+        <h3>Suggested Prompts</h3>
+        <button type="button" class="prompt-suggestion__close" aria-label="Close">×</button>
+      </header>
+      <p class="prompt-suggestion__summary"></p>
+      <div class="prompt-suggestion__output" aria-live="polite"></div>
+      <div class="prompt-suggestion__actions">
+        <button type="button" class="prompt-suggestion__copy">Copy to clipboard</button>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(suggestionModal);
+
+  suggestionOutputEl = suggestionModal.querySelector(".prompt-suggestion__output");
+  suggestionSummaryEl = suggestionModal.querySelector(".prompt-suggestion__summary");
+  suggestionCopyBtn = suggestionModal.querySelector(".prompt-suggestion__copy");
+  const closeBtn = suggestionModal.querySelector(".prompt-suggestion__close");
+
+  if (closeBtn) {
+    closeBtn.addEventListener("click", () => closeSuggestionsModal());
+  }
+
+  suggestionModal.addEventListener("click", (event) => {
+    if (event.target === suggestionModal) {
+      closeSuggestionsModal();
+    }
+  });
+
+  if (suggestionCopyBtn) {
+    suggestionCopyBtn.addEventListener("click", () => copySuggestionText());
+  }
+
+  return suggestionModal;
+}
+
+function copySuggestionText() {
+  if (!suggestionOutputEl) return;
+  const text = suggestionOutputEl.dataset?.value || "";
+  if (!text) return;
+  navigator.clipboard
+    .writeText(text)
+    .then(() => {
+      showToast("Suggested prompts copied");
+    })
+    .catch(() => {
+      showToast("Couldn't copy prompts");
+    });
+}
+
+function closeSuggestionsModal() {
+  if (!suggestionModal) return;
+  suggestionModal.classList.remove("open");
+  suggestionModal.setAttribute("aria-hidden", "true");
+  if (suggestionKeyHandler) {
+    document.removeEventListener("keydown", suggestionKeyHandler);
+    suggestionKeyHandler = null;
+  }
+}
+
+function openSuggestionsModal() {
+  if (!copiedArtists.size) {
+    showToast("Copy a few artists first!");
+    return;
+  }
+  const overlay = ensureSuggestionModal();
+  const selected = getSelectedArtistsForPrompts();
+  const suggestions = buildPromptSuggestions(selected);
+  const line = suggestions.join(", ");
+
+  if (suggestionSummaryEl) {
+    suggestionSummaryEl.textContent = selected.length
+      ? `Based on ${selected.length} selected artist${selected.length > 1 ? "s" : ""}`
+      : "Select artists with the checkboxes first.";
+  }
+
+  if (suggestionOutputEl) {
+    if (line) {
+      suggestionOutputEl.textContent = line;
+      suggestionOutputEl.dataset.value = line;
+    } else {
+      suggestionOutputEl.textContent = selected.length
+        ? "No overlapping tags left to recommend."
+        : "No artists selected.";
+      suggestionOutputEl.dataset.value = "";
+    }
+  }
+
+  if (suggestionCopyBtn) {
+    const disabled = !line;
+    suggestionCopyBtn.disabled = disabled;
+    suggestionCopyBtn.setAttribute("aria-disabled", disabled ? "true" : "false");
+    if (!disabled) {
+      suggestionCopyBtn.focus({ preventScroll: true });
+    }
+  }
+
+  overlay.classList.add("open");
+  overlay.setAttribute("aria-hidden", "false");
+
+  if (!suggestionKeyHandler) {
+    suggestionKeyHandler = (event) => {
+      if (event.key === "Escape") closeSuggestionsModal();
+    };
+    document.addEventListener("keydown", suggestionKeyHandler);
+  }
 }
 
 /**
@@ -363,6 +621,7 @@ function setAllArtists(artists) {
  */
 function setCopiedArtists(artists) {
   copiedArtists = artists;
+  selectedPromptArtists = new Set(artists);
 }
 
 /**

--- a/modules/tag-explorer.js
+++ b/modules/tag-explorer.js
@@ -1,215 +1,439 @@
-import { getActiveTags, getKinkTags, toggleTag, getArtistNameFilter, handleArtistNameFilter } from "./tags.js";
+import {
+  getActiveTags,
+  getKinkTags,
+  toggleTag,
+  getArtistNameFilter,
+  handleArtistNameFilter,
+  handleTagSearch,
+  clearAllTags,
+} from "./tags.js";
+
+const MAX_TAG_SELECTION = 2;
 
 let allArtists = [];
-let allArtistsCache = null;
+let overlayEl = null;
+let panelEl = null;
+let searchInputEl = null;
+let nameInputEl = null;
+let groupsContainerEl = null;
+let overlaySelectedEl = null;
+let pinnedSelectedEl = null;
+let limitNoticeEl = null;
+let clearButtonEl = null;
+let isInitialized = false;
+let isOpen = false;
+let escapeListener = null;
+let searchValue = "";
+let searchValueLower = "";
+let limitMessageTimer = null;
 
 function setAllArtists(artists) {
-  if (allArtistsCache && JSON.stringify(allArtistsCache) === JSON.stringify(artists)) return;
-  allArtists = Array.isArray(artists) ? artists : [];
-  allArtistsCache = artists;
+  if (!Array.isArray(artists)) {
+    allArtists = [];
+    return;
+  }
+  allArtists = [...artists];
 }
 
-function getFilteredArtists(active) {
-  const nameFilter = (getArtistNameFilter && getArtistNameFilter() || '').toLowerCase();
-  return allArtists.filter((a) => {
-    const tags = Array.isArray(a.kinkTags) ? a.kinkTags : [];
-    if (![...active].every((t) => tags.includes(t))) return false;
-    if (nameFilter && !a.artistName.toLowerCase().includes(nameFilter)) return false;
+function getFilteredArtists(active = getActiveTags()) {
+  const activeTags = active instanceof Set ? active : new Set(active || []);
+  const nameFilter = (typeof getArtistNameFilter === "function"
+    ? getArtistNameFilter() || ""
+    : "").toLowerCase();
+
+  return allArtists.filter((artist) => {
+    const tags = Array.isArray(artist?.kinkTags) ? artist.kinkTags : [];
+    if (![...activeTags].every((tag) => tags.includes(tag))) return false;
+    if (nameFilter && !artist.artistName.toLowerCase().includes(nameFilter)) {
+      return false;
+    }
     return true;
   });
 }
 
-function getFilteredCounts(active) {
+function getFilteredCounts(active = getActiveTags()) {
   const counts = {};
-  const countedArtists = {};
   const filtered = getFilteredArtists(active);
-  filtered.forEach((a) => {
-    const artistName = a.artistName;
-    const tags = Array.isArray(a.kinkTags) ? a.kinkTags : [];
-    tags.forEach((t) => {
-      if (!countedArtists[t]) countedArtists[t] = new Set();
-      if (!countedArtists[t].has(artistName)) {
-        countedArtists[t].add(artistName);
-        counts[t] = (counts[t] || 0) + 1;
-      }
+  filtered.forEach((artist) => {
+    const tags = Array.isArray(artist?.kinkTags) ? artist.kinkTags : [];
+    tags.forEach((tag) => {
+      counts[tag] = (counts[tag] || 0) + 1;
     });
   });
   return counts;
 }
 
-// No longer needed: groupTags. We'll use kink categories directly.
+function ensurePinnedSelectedContainer() {
+  if (typeof document === "undefined") return null;
+  if (pinnedSelectedEl && document.body.contains(pinnedSelectedEl)) {
+    return pinnedSelectedEl;
+  }
+  let container = document.getElementById("selected-tags");
+  if (!container) {
+    container = document.createElement("section");
+    container.id = "selected-tags";
+    container.className = "selected-tags-bar";
+    container.setAttribute("aria-label", "Active tag filters");
+    const main = document.querySelector("main") || document.body;
+    main.insertBefore(container, main.firstChild || null);
+  } else if (!container.classList.contains("selected-tags-bar")) {
+    container.classList.add("selected-tags-bar");
+  }
+  pinnedSelectedEl = container;
+  return pinnedSelectedEl;
+}
 
-function openTagExplorer() {
-  const existing = document.querySelector('.tag-explorer-wrapper');
-  if (existing) existing.remove();
-
-  const wrapper = document.createElement('div');
-  wrapper.className = 'tag-explorer-wrapper';
-  wrapper.addEventListener('click', (e) => {
-    if (e.target === wrapper) wrapper.remove();
+function createTagPill(tag, options = {}) {
+  const pill = document.createElement("button");
+  pill.type = "button";
+  pill.className = "selected-tag-pill";
+  if (options.compact) pill.classList.add("compact");
+  pill.textContent = tag.replace(/_/g, " ");
+  pill.setAttribute("data-tag", tag);
+  pill.setAttribute("aria-label", `Remove tag ${tag.replace(/_/g, " ")}`);
+  pill.addEventListener("click", () => {
+    toggleTag(tag);
   });
+  return pill;
+}
 
-  const sidebar = document.createElement('div');
-  sidebar.className = 'tag-explorer';
-  wrapper.appendChild(sidebar);
-  document.body.appendChild(wrapper);
+function clearSelectionLimitMessage() {
+  if (!limitNoticeEl) return;
+  limitNoticeEl.textContent = "";
+  limitNoticeEl.classList.remove("visible");
+  if (limitMessageTimer) {
+    clearTimeout(limitMessageTimer);
+    limitMessageTimer = null;
+  }
+}
 
-  const header = document.createElement('div');
-  header.className = 'tag-explorer-header';
-  const title = document.createElement('h3');
-  title.textContent = 'Tags';
-  header.appendChild(title);
-  const closeBtn = document.createElement('button');
-  closeBtn.className = 'zoom-close';
-  closeBtn.textContent = '×';
-  closeBtn.onclick = () => wrapper.remove();
-  closeBtn.title = 'Close';
-  header.appendChild(closeBtn);
-  const clearBtn = document.createElement('button');
-  clearBtn.className = 'tag-explorer-clear';
-  clearBtn.textContent = 'Clear';
-  clearBtn.onclick = () => {
-    // Clear all tags using toggleTag until none left
-    const active = getActiveTags();
-    if (active && active.size) {
-      [...active].forEach(tag => toggleTag(tag));
-    }
-    searchInput.value = '';
-    nameInput.value = '';
-    handleArtistNameFilter('');
-    renderList();
-  };
-  header.appendChild(clearBtn);
-  const searchInput = document.createElement('input');
-  searchInput.type = 'text';
-  searchInput.placeholder = 'Search tags';
-  searchInput.oninput = renderList;
-  header.appendChild(searchInput);
-  const nameInput = document.createElement('input');
-  nameInput.type = 'text';
-  nameInput.placeholder = 'Filter artists';
-  nameInput.value = getArtistNameFilter ? getArtistNameFilter() : '';
-  nameInput.oninput = () => {
-    handleArtistNameFilter(nameInput.value);
-    renderList();
-  };
-  header.appendChild(nameInput);
-  sidebar.appendChild(header);
+function showSelectionLimitMessage() {
+  if (!limitNoticeEl) return;
+  limitNoticeEl.textContent = `You can only select up to ${MAX_TAG_SELECTION} tags at a time.`;
+  limitNoticeEl.classList.add("visible");
+  if (limitMessageTimer) clearTimeout(limitMessageTimer);
+  limitMessageTimer = setTimeout(() => {
+    clearSelectionLimitMessage();
+  }, 2200);
+}
 
-
-  // Selected tags bar (global, outside modal)
-  let selectedTagsBar = document.querySelector('.selected-tags-bar');
-  if (!selectedTagsBar) {
-    selectedTagsBar = document.createElement('div');
-    selectedTagsBar.className = 'selected-tags-bar';
-    // Insert after .tag-explorer-bar if present
-    const topBar = document.querySelector('.tag-explorer-bar, #tag-explorer-bar');
-    if (topBar && topBar.parentNode) {
-      topBar.parentNode.insertBefore(selectedTagsBar, topBar.nextSibling);
-    } else {
-      document.body.insertBefore(selectedTagsBar, document.body.firstChild);
+function emitOverlayToggle(open) {
+  if (typeof document === "undefined" || typeof document.dispatchEvent !== "function") {
+    return;
+  }
+  const detail = { open: Boolean(open) };
+  try {
+    document.dispatchEvent(new CustomEvent("tagFilters:toggle", { detail }));
+  } catch (err) {
+    if (typeof document.createEvent === "function") {
+      try {
+        const evt = document.createEvent("CustomEvent");
+        evt.initCustomEvent("tagFilters:toggle", false, false, detail);
+        document.dispatchEvent(evt);
+      } catch {
+        // ignore
+      }
     }
   }
-  // Style for sticky and layout is handled in CSS
+}
 
-  const groupsContainer = document.createElement('div');
-  groupsContainer.className = 'tag-explorer-groups';
-  sidebar.appendChild(groupsContainer);
-  const kinkCategories = getKinkTags(); // [{category, tags:[]}, ...]
-  const openGroups = new Set();
-
-  function renderList() {
-    const active = getActiveTags();
-    const counts = getFilteredCounts(active);
-    const searchText = searchInput.value.toLowerCase();
-    // Render selected tags bar (global)
-    selectedTagsBar.innerHTML = '';
-    if (active.size > 0) {
-      const label = document.createElement('span');
-      label.textContent = 'Selected:';
-      label.style.fontWeight = 'bold';
-      label.style.marginRight = '0.5em';
-      label.style.color = '#a0005a';
-      label.style.background = '#fff0fa';
-      label.style.padding = '0.2em 0.7em';
-      label.style.borderRadius = '1em';
-      label.style.fontSize = '1.05em';
-      selectedTagsBar.appendChild(label);
-      active.forEach((tag) => {
-        const pill = document.createElement('span');
-        pill.className = 'selected-tag-pill';
-        pill.textContent = tag.replace(/_/g, ' ');
-        pill.title = 'Remove tag';
-        pill.style.cursor = 'pointer';
-        pill.style.background = 'linear-gradient(90deg, #ffd6f6 0%, #fd7bc5 100%)';
-        pill.style.color = '#a0005a';
-        pill.style.border = '1.5px solid #fd7bc5';
-        pill.style.padding = '0.4em 1em';
-        pill.style.borderRadius = '2em';
-        pill.style.fontWeight = '500';
-        pill.style.boxShadow = '0 1px 4px #fd7bc540';
-        pill.onclick = () => {
-          toggleTag(tag);
-          renderList();
-        };
-        selectedTagsBar.appendChild(pill);
-      });
+function fillSelectedContainer(container, tags, options = {}) {
+  if (!container) return;
+  container.innerHTML = "";
+  if (!tags.length) {
+    container.classList.add("is-empty");
+    if (options.placeholder) {
+      const message = document.createElement("p");
+      message.className = "selected-tags-empty";
+      message.textContent = options.placeholder;
+      container.appendChild(message);
     }
-    groupsContainer.innerHTML = '';
-    // Flatten all tags for verification
-    let allTagsFlat = [];
-    kinkCategories.forEach(cat => allTagsFlat.push(...cat.tags));
-    // --- Verification: check for lost tags ---
-    // If you want to check for lost tags, you can compare allTagsFlat to the original list.
-    // ---
-    kinkCategories.forEach(({ category, tags }) => {
-      // Filter tags by search and by presence in filtered artists
-      const filteredTags = tags
-        .filter((t) => t.toLowerCase().includes(searchText))
-        .filter((t) => counts[t] || active.has(t));
-      if (filteredTags.length === 0) return;
-      const section = document.createElement('div');
-      section.className = 'tag-group';
-      if (openGroups.has(category) || searchText || filteredTags.some((t) => active.has(t))) {
-        section.classList.add('open');
+    return;
+  }
+  container.classList.remove("is-empty");
+  if (options.showLabel) {
+    const label = document.createElement("span");
+    label.className = "selected-tags-label";
+    label.textContent = "Active filters";
+    container.appendChild(label);
+  }
+  const list = document.createElement("div");
+  list.className = "selected-tags-list";
+  tags.forEach((tag) => {
+    list.appendChild(createTagPill(tag, { compact: options.compact }));
+  });
+  container.appendChild(list);
+}
+
+function renderSelectedTags() {
+  const active = Array.from(getActiveTags());
+  const overlayPlaceholder = active.length
+    ? null
+    : "No filters applied. Choose tags to narrow results.";
+  fillSelectedContainer(overlaySelectedEl, active, {
+    placeholder: overlayPlaceholder,
+    compact: false,
+  });
+  const pinned = ensurePinnedSelectedContainer();
+  fillSelectedContainer(pinned, active, {
+    showLabel: true,
+    compact: true,
+    placeholder: "No filters active",
+  });
+  if (active.length < MAX_TAG_SELECTION) {
+    clearSelectionLimitMessage();
+  }
+}
+
+function handleTagToggle(tag) {
+  const active = getActiveTags();
+  if (!active.has(tag) && active.size >= MAX_TAG_SELECTION) {
+    if (typeof navigator !== "undefined" && navigator.vibrate) {
+      try {
+        navigator.vibrate(50);
+      } catch {
+        // ignore vibration errors
       }
-      const head = document.createElement('div');
-      head.className = 'tag-group-header';
-      head.textContent = category;
-      head.onclick = () => {
-        if (openGroups.has(category)) openGroups.delete(category);
-        else openGroups.add(category);
-        renderList();
-      };
-      section.appendChild(head);
-      const tagsDiv = document.createElement('div');
-      tagsDiv.className = 'tag-group-tags';
-      filteredTags.forEach((tag) => {
-        const btn = document.createElement('button');
-        btn.className = 'tag-button';
-        btn.textContent = `${tag.replace(/_/g,' ')} (${counts[tag] || 0})`;
-        // Only highlight if tag is in active set
-        if (active.has(tag)) btn.classList.add('active');
-        btn.onclick = () => {
-          toggleTag(tag);
-          renderList();
-        };
-        tagsDiv.appendChild(btn);
-      });
-      section.appendChild(tagsDiv);
-      groupsContainer.appendChild(section);
+    }
+    showSelectionLimitMessage();
+    return;
+  }
+  toggleTag(tag);
+  renderExplorer();
+}
+
+function formatTagLabel(tag) {
+  return tag.replace(/_/g, " ");
+}
+
+function renderCategories() {
+  if (!groupsContainerEl) return;
+  groupsContainerEl.innerHTML = "";
+  const active = getActiveTags();
+  const counts = getFilteredCounts(active);
+  const categories = getKinkTags();
+  let renderedAny = false;
+
+  categories.forEach(({ category, tags }) => {
+    const matchingTags = tags.filter((tag) => {
+      if (searchValueLower && !tag.toLowerCase().includes(searchValueLower)) {
+        return false;
+      }
+      const count = counts[tag] || 0;
+      return count > 0 || active.has(tag);
+    });
+
+    if (matchingTags.length === 0) return;
+
+    renderedAny = true;
+    const section = document.createElement("section");
+    section.className = "filter-category";
+    const shouldOpen =
+      searchValueLower !== "" || matchingTags.some((tag) => active.has(tag));
+    if (shouldOpen) section.classList.add("open");
+
+    const header = document.createElement("button");
+    header.type = "button";
+    header.className = "filter-category__header";
+    header.textContent = category;
+    header.setAttribute("aria-expanded", shouldOpen ? "true" : "false");
+    header.addEventListener("click", () => {
+      const nowOpen = !section.classList.contains("open");
+      section.classList.toggle("open", nowOpen);
+      header.setAttribute("aria-expanded", nowOpen ? "true" : "false");
+    });
+    section.appendChild(header);
+
+    const tagList = document.createElement("div");
+    tagList.className = "filter-category__tags";
+
+    matchingTags.forEach((tag) => {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "filter-tag-button";
+      btn.setAttribute("data-tag", tag);
+      const count = counts[tag] || 0;
+      btn.innerHTML = `
+        <span class="filter-tag-button__label">${formatTagLabel(tag)}</span>
+        <span class="filter-tag-button__count">${count}</span>
+      `;
+      const isActive = active.has(tag);
+      btn.classList.toggle("is-active", isActive);
+      btn.setAttribute("aria-pressed", isActive ? "true" : "false");
+      btn.addEventListener("click", () => handleTagToggle(tag));
+      tagList.appendChild(btn);
+    });
+
+    section.appendChild(tagList);
+    groupsContainerEl.appendChild(section);
+  });
+
+  if (!renderedAny) {
+    const emptyState = document.createElement("p");
+    emptyState.className = "filter-empty-state";
+    emptyState.textContent = searchValueLower
+      ? "No tags match your search."
+      : "No tags available for the current filters.";
+    groupsContainerEl.appendChild(emptyState);
+  }
+}
+
+function renderExplorer() {
+  renderSelectedTags();
+  renderCategories();
+}
+
+function bindEscapeListener() {
+  if (typeof document === "undefined") return;
+  if (escapeListener) return;
+  escapeListener = (event) => {
+    if (event.key === "Escape") {
+      closeTagExplorer();
+    }
+  };
+  document.addEventListener("keydown", escapeListener);
+}
+
+function unbindEscapeListener() {
+  if (typeof document === "undefined") return;
+  if (!escapeListener) return;
+  document.removeEventListener("keydown", escapeListener);
+  escapeListener = null;
+}
+
+function openTagExplorer() {
+  if (!isInitialized) initTagExplorer();
+  if (!overlayEl || isOpen) return;
+  isOpen = true;
+  overlayEl.classList.add("open");
+  overlayEl.setAttribute("aria-hidden", "false");
+  document.body.classList.add("tag-filter-open");
+  if (panelEl) {
+    panelEl.setAttribute("tabindex", "-1");
+    panelEl.focus({ preventScroll: true });
+  }
+  if (searchInputEl) {
+    searchInputEl.value = searchValue;
+  }
+  if (nameInputEl) {
+    const currentName =
+      typeof getArtistNameFilter === "function" ? getArtistNameFilter() : "";
+    nameInputEl.value = currentName || "";
+  }
+  renderExplorer();
+  bindEscapeListener();
+  emitOverlayToggle(true);
+}
+
+function closeTagExplorer() {
+  if (!overlayEl || !isOpen) return;
+  isOpen = false;
+  overlayEl.classList.remove("open");
+  overlayEl.setAttribute("aria-hidden", "true");
+  document.body.classList.remove("tag-filter-open");
+  unbindEscapeListener();
+  emitOverlayToggle(false);
+}
+
+function handleSearchInput(value) {
+  searchValue = value;
+  searchValueLower = value.trim().toLowerCase();
+  handleTagSearch(value);
+  renderCategories();
+}
+
+function initTagExplorer() {
+  if (isInitialized || typeof document === "undefined") return;
+  ensurePinnedSelectedContainer();
+
+  overlayEl = document.createElement("div");
+  overlayEl.className = "filter-overlay";
+  overlayEl.setAttribute("aria-hidden", "true");
+  overlayEl.innerHTML = `
+    <div class="filter-panel" id="tag-filter-panel" role="dialog" aria-modal="true" aria-label="Tag filters">
+      <div class="filter-panel__handle" aria-hidden="true"></div>
+      <header class="filter-panel__header">
+        <h2>Filters</h2>
+        <button type="button" class="filter-panel__close" aria-label="Close filters">×</button>
+      </header>
+      <div class="filter-panel__controls">
+        <div class="filter-panel__inputs">
+          <label class="visually-hidden" for="tag-filter-search">Search tags</label>
+          <input id="tag-filter-search" class="filter-panel__search" type="search" placeholder="Search tags" autocomplete="off" />
+          <label class="visually-hidden" for="tag-filter-name">Filter artists by name</label>
+          <input id="tag-filter-name" class="filter-panel__search" type="search" placeholder="Filter artists by name" autocomplete="off" />
+        </div>
+        <div class="filter-panel__actions">
+          <button type="button" class="filter-panel__clear">Clear all</button>
+        </div>
+        <p class="filter-panel__notice" aria-live="assertive"></p>
+      </div>
+      <div class="filter-panel__selected" aria-live="polite"></div>
+      <div class="filter-panel__groups"></div>
+    </div>
+  `;
+
+  document.body.appendChild(overlayEl);
+
+  panelEl = overlayEl.querySelector("#tag-filter-panel");
+  searchInputEl = overlayEl.querySelector("#tag-filter-search");
+  nameInputEl = overlayEl.querySelector("#tag-filter-name");
+  groupsContainerEl = overlayEl.querySelector(".filter-panel__groups");
+  overlaySelectedEl = overlayEl.querySelector(".filter-panel__selected");
+  limitNoticeEl = overlayEl.querySelector(".filter-panel__notice");
+  clearButtonEl = overlayEl.querySelector(".filter-panel__clear");
+
+  overlayEl.addEventListener("click", (event) => {
+    if (event.target === overlayEl) {
+      closeTagExplorer();
+    }
+  });
+
+  const closeBtn = overlayEl.querySelector(".filter-panel__close");
+  if (closeBtn) {
+    closeBtn.addEventListener("click", () => closeTagExplorer());
+  }
+
+  if (searchInputEl) {
+    searchInputEl.addEventListener("input", (event) => {
+      handleSearchInput(event.target.value || "");
     });
   }
 
-  renderList();
-  requestAnimationFrame(() => sidebar.classList.add('open'));
+  if (nameInputEl) {
+    nameInputEl.addEventListener("input", (event) => {
+      handleArtistNameFilter(event.target.value || "");
+    });
+  }
 
-  document.addEventListener('keydown', function esc(e) {
-    if (e.key === 'Escape') {
-      wrapper.remove();
-      document.removeEventListener('keydown', esc);
+  if (clearButtonEl) {
+    clearButtonEl.addEventListener("click", (event) => {
+      event.preventDefault();
+      searchInputEl && (searchInputEl.value = "");
+      handleSearchInput("");
+      nameInputEl && (nameInputEl.value = "");
+      handleArtistNameFilter("");
+      clearAllTags();
+      renderExplorer();
+    });
+  }
+
+  document.addEventListener("tags:updated", () => {
+    renderSelectedTags();
+    if (isOpen) {
+      renderCategories();
+      if (nameInputEl) {
+        const currentName =
+          typeof getArtistNameFilter === "function"
+            ? getArtistNameFilter()
+            : "";
+        nameInputEl.value = currentName || "";
+      }
     }
   });
+
+  renderExplorer();
+  isInitialized = true;
 }
 
-export { openTagExplorer, setAllArtists, getFilteredCounts };
+export { openTagExplorer, initTagExplorer, setAllArtists, getFilteredCounts };

--- a/modules/tags.js
+++ b/modules/tags.js
@@ -149,6 +149,29 @@ const tagIcons = {
 
 let tagSearchMode = "contains"; // "contains", "starts", "ends"
 
+function emitTagUpdate() {
+  if (typeof document === "undefined" || typeof document.dispatchEvent !== "function") {
+    return;
+  }
+  const detail = {
+    activeTags: Array.from(activeTags),
+    artistNameFilter,
+  };
+  try {
+    document.dispatchEvent(new CustomEvent("tags:updated", { detail }));
+  } catch (err) {
+    if (typeof document.createEvent === "function") {
+      try {
+        const evt = document.createEvent("CustomEvent");
+        evt.initCustomEvent("tags:updated", false, false, detail);
+        document.dispatchEvent(evt);
+      } catch {
+        // ignore
+      }
+    }
+  }
+}
+
 /**
  * Spawns a taunt bubble for a selected tag
  */
@@ -174,6 +197,7 @@ function spawnBubble(tag) {
  * Updates the filtered results summary section
  */
 function updateFilteredResultsSummary(filteredCount, totalCount) {
+  if (typeof document === "undefined") return;
   const filteredResultsEl = document.getElementById("filtered-results");
   if (!filteredResultsEl) return;
 
@@ -203,11 +227,6 @@ function updateFilteredResultsSummary(filteredCount, totalCount) {
  * Renders the tag filter buttons based on current state
  */
 function renderTagButtons() {
-  if (!tagButtonsContainer) return;
-  tagButtonsContainer.innerHTML = "";
-  tagButtonsContainer.setAttribute("role", "group");
-  tagButtonsContainer.setAttribute("aria-label", "Tag filters");
-
   // Get artists matching current filters
   const filteredArtists = allArtists.filter((artist) => {
     const tags = artist.kinkTags || [];
@@ -220,6 +239,14 @@ function renderTagButtons() {
 
   // Update filtered results summary
   updateFilteredResultsSummary(filteredArtists.length, allArtists.length);
+
+  if (clearTagsBtn) clearTagsBtn.style.display = activeTags.size ? "" : "none";
+
+  if (!tagButtonsContainer) return;
+
+  tagButtonsContainer.innerHTML = "";
+  tagButtonsContainer.setAttribute("role", "group");
+  tagButtonsContainer.setAttribute("aria-label", "Tag filters");
 
   // Get all tags present in filtered artists
   const possibleTags = new Set();
@@ -328,24 +355,6 @@ function renderTagButtons() {
     };
     tagButtonsContainer.prepend(button);
   }
-
-  if (clearTagsBtn) clearTagsBtn.style.display = activeTags.size ? "" : "none";
-
-  if (selectedTagsBar) {
-    selectedTagsBar.innerHTML = "";
-    if (activeTags.size) {
-      selectedTagsBar.style.display = "flex";
-      activeTags.forEach((tag) => {
-        const pill = document.createElement("button");
-        pill.className = "selected-tag";
-        pill.textContent = tag.replaceAll("_", " ");
-        pill.onclick = () => toggleTag(tag);
-        selectedTagsBar.appendChild(pill);
-      });
-    } else {
-      selectedTagsBar.style.display = "none";
-    }
-  }
 }
 
 /**
@@ -357,6 +366,7 @@ function clearAllTags() {
   if (navigator.vibrate) navigator.vibrate(50);
   if (renderArtists) renderArtists(true); // <-- force full update
   if (setRandomBackground) setRandomBackground();
+  emitTagUpdate();
 }
 
 /**
@@ -378,6 +388,7 @@ function toggleTag(tag) {
   if (renderArtists) renderArtists(true);
   if (setRandomBackground) setRandomBackground();
   if (navigator.vibrate) navigator.vibrate(50);
+  emitTagUpdate();
 }
 
 /**
@@ -386,6 +397,7 @@ function toggleTag(tag) {
 function handleTagSearch(value) {
   searchFilter = value;
   renderTagButtons();
+  emitTagUpdate();
 }
 
 /**
@@ -403,6 +415,7 @@ function handleArtistNameFilter(value) {
   artistNameFilter = value.trim().toLowerCase();
   renderTagButtons(); // Update the summary display
   if (renderArtists) renderArtists(true);
+  emitTagUpdate();
 }
 
 /**

--- a/style.css
+++ b/style.css
@@ -102,23 +102,74 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
 
 /* Selected tags display */
 .selected-tags-bar {
-  display: none;
+  display: flex;
+  align-items: center;
   flex-wrap: wrap;
+  gap: 0.55rem;
   justify-content: flex-start;
+  padding: 0.55rem 0.9rem;
+  margin: 0.35rem auto;
+  max-width: min(1080px, 95vw);
+  border-radius: 999px;
+  border: 2px solid rgba(253, 123, 197, 0.45);
+  background: linear-gradient(120deg, rgba(255, 214, 246, 0.92) 0%, rgba(253, 123, 197, 0.96) 100%);
+  box-shadow: 0 6px 18px rgba(253, 123, 197, 0.24);
+  color: #52143b;
+  transition: opacity 0.2s ease;
 }
 
-.selected-tag {
-  background: var(--accent1);
-  color: #fff;
+.selected-tags-bar.is-empty {
+  display: none;
+}
+
+.selected-tags-label {
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+}
+
+.selected-tags-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.selected-tag-pill {
   border: none;
-  border-radius: var(--radius);
-  padding: 0.2em 0.6em;
-  font-size: 0.9em;
+  border-radius: 999px;
+  padding: 0.3rem 0.85rem;
+  background: rgba(255, 255, 255, 0.28);
+  color: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  transition: background 0.18s ease, transform 0.18s ease;
 }
 
-.selected-tag:hover {
-  background: var(--accent2);
+.selected-tag-pill::after {
+  content: "\00d7";
+  font-size: 0.85em;
+  opacity: 0.85;
+}
+
+.selected-tag-pill.compact {
+  padding: 0.25rem 0.7rem;
+  font-size: 0.82rem;
+}
+
+.selected-tag-pill:hover {
+  background: rgba(255, 255, 255, 0.4);
+  transform: translateY(-1px);
+}
+
+.selected-tags-empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(82, 20, 59, 0.75);
 }
 
 .sidebar {
@@ -164,6 +215,113 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
   opacity: 1;
   visibility: visible;
   pointer-events: auto;
+}
+
+.sidebar-copied-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-top: 0.6rem;
+}
+
+.copied-artist-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: 16px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.04);
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.copied-artist-row:hover {
+  transform: translateY(-1px);
+  border-color: rgba(253, 123, 197, 0.28);
+}
+
+.copied-artist-row.selected {
+  border-color: rgba(253, 123, 197, 0.45);
+  background: rgba(253, 123, 197, 0.16);
+}
+
+.copied-artist-select-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.copied-artist-select {
+  width: 1.05rem;
+  height: 1.05rem;
+  cursor: pointer;
+  accent-color: #fd7bc5;
+}
+
+.copied-artist-info {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.copied-artist-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.sidebar-artist-name {
+  font-weight: 600;
+}
+
+.sidebar-latest-tag {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(253, 123, 197, 0.85);
+}
+
+.sidebar-empty {
+  padding: 1rem 0;
+  text-align: center;
+  font-size: 0.88rem;
+  color: rgba(255, 255, 255, 0.68);
+}
+
+.sidebar-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  margin-top: 0.85rem;
+}
+
+.sidebar-selection-note {
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.sidebar-suggest-btn {
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(120deg, #ffd6f6 0%, #fd7bc5 100%);
+  color: #52143b;
+  font-weight: 700;
+  padding: 0.5rem 1.1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.sidebar-suggest-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px rgba(253, 123, 197, 0.28);
+}
+
+.sidebar-suggest-btn:disabled,
+.sidebar-suggest-btn[aria-disabled="true"] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
 }
 
 /* Sidebar Wrapper: toggles visibility of sidebar */
@@ -522,146 +680,331 @@ body > header, body > main, body > aside, body > nav, #artist-gallery {
   backdrop-filter: blur(8px) saturate(1.08);
 }
 
-.tag-explorer {
-  background: linear-gradient(120deg, rgba(255,255,255,0.92) 60%, rgba(253,214,246,0.98) 100%) !important;
-  backdrop-filter: blur(14px) saturate(1.13) !important;
-  border-radius: 1.1em !important;
-  box-shadow: 0 2px 16px rgba(253,123,197,0.13), 0 1.5px 8px rgba(255,99,165,0.10) !important;
-  border: 2.5px solid #fd7bc540 !important;
-  position: relative;
-  overflow: visible;
-  display: flex;
-  flex-direction: column;
-  max-height: 85vh;
-  max-width: 90vw;
-  width: 500px;
-}
-
-.tag-explorer-header {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 0.5em;
-  padding: 0.5em;
-  margin-bottom: 0.5em;
-}
-
-.tag-explorer-header h3 {
-    font-size: 1.4em;
-    font-weight: 700;
-    color: var(--accent1);
-    text-align: center;
-    margin: 0 0 0.5em 0;
-}
-
-.tag-explorer-header input {
-    width: 100%;
-    padding: 0.5em;
-    border-radius: 8px;
-    border: 1px solid #fd7bc5;
-    background: white;
-    color: var(--accent1);
-    font-size: 1em;
-    box-sizing: border-box;
-}
-
-/* In-page tag filter panel */
-.filter-controls {
+body.tag-filter-open {
   overflow: hidden;
-  max-height: 0;
-  margin-bottom: 0;
-  transition: max-height 0.3s ease;
 }
 
-.filter-controls.open {
-  max-height: 1000px; /* enough to show contents */
-  margin-bottom: 1.5em;
-}
-
-.filter-inputs {
+.filter-overlay {
+  position: fixed;
+  inset: 0;
+  padding: 1.25rem 0.8rem 0.8rem;
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.5em;
+  align-items: flex-end;
+  justify-content: center;
+  background: rgba(17, 6, 21, 0.58);
+  backdrop-filter: blur(8px);
+  z-index: 14000;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.24s ease, visibility 0.24s ease;
+}
+
+.filter-overlay.open {
+  opacity: 1;
+  visibility: visible;
+}
+
+.filter-panel {
+  width: min(640px, 100%);
+  max-height: min(88vh, 760px);
+  background: linear-gradient(160deg, rgba(43, 16, 56, 0.96) 0%, rgba(24, 8, 35, 0.94) 100%);
+  border-radius: 24px 24px 0 0;
+  box-shadow: 0 -18px 38px rgba(7, 2, 12, 0.48);
+  border: 1.5px solid rgba(253, 123, 197, 0.32);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.1rem 1.4rem 1.6rem;
+  transform: translateY(110%);
+  transition: transform 0.3s ease;
+}
+
+.filter-overlay.open .filter-panel {
+  transform: translateY(0);
+}
+
+.filter-panel__handle {
+  width: 48px;
+  height: 5px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.3);
+  margin: 0 auto 0.75rem;
+}
+
+.filter-panel__header {
+  display: flex;
   align-items: center;
-  margin-bottom: 0.5em;
+  justify-content: space-between;
+  gap: 0.75rem;
 }
 
-.filter-controls input {
-  padding: 0.5em;
-  border-radius: 8px;
-  border: 1px solid #fd7bc5;
-  background: white;
-  color: var(--accent1);
-  font-size: 1em;
+.filter-panel__header h2 {
+  margin: 0;
+  font-size: 1.28rem;
+  color: #ffe3f7;
+  letter-spacing: 0.02em;
 }
 
-.tag-buttons {
-  display: block;
-}
-
-.tag-button {
-  background: linear-gradient(90deg, #ffd6f6 0%, #fd7bc5 100%) !important;
-  border: 1px solid #fd7bc5 !important;
-  color: var(--accent1) !important;
-  box-shadow: 0 1px 4px #fd7bc540 !important;
-  font-family: var(--btn-font);
-  display: flex;
+.filter-panel__close {
+  border: none;
+  background: rgba(255, 255, 255, 0.16);
+  color: #fff;
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 1.2rem;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 1em !important;
-  padding: 0.4em 0.8em !important;
-  margin: 0.1em !important;
-  cursor: pointer;
-  font-size: 0.9em;
-  font-weight: 600;
-  transition: all 0.18s !important;
-  outline: none !important;
-  word-break: break-word !important;
-  text-align: center !important;
-  user-select: none;
+  transition: transform 0.2s ease, background 0.2s ease;
 }
-  
-.tag-button.active {
-  background: linear-gradient(90deg, #ff63a5 0%, #fd7bc5 100%) !important;
-  color: #fff !important;
-  box-shadow: 0 4px 16px #fd7bc5cc !important;
-  transform: scale(1.09);
-  font-weight: 800;
+
+.filter-panel__close:hover {
+  background: rgba(253, 123, 197, 0.45);
+  transform: rotate(90deg);
 }
-.tag-button:focus {
-  background: #fff8fc !important;
-  color: var(--accent1) !important;
-  outline: 2.5px solid #fd7bc5 !important;
-  outline-offset: 2px;
-}
-.tag-group {
-  margin-bottom: 1.2em;
-}
-.tag-group-header {
-  font-size: 1.18em;
-  font-weight: 700;
-  color: var(--accent1);
-  background: linear-gradient(90deg, #ffd6f6 0%, #fd7bc5 100%);
-  padding: 0.7em 1.1em;
-  border-radius: 1em;
-  margin-bottom: 0.5em;
-  box-shadow: 0 1px 4px #fd7bc540;
-  cursor: pointer;
-}
-.tag-group-tags {
+
+.filter-panel__controls {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.3em;
-  margin-top: 0.2em;
+  flex-direction: column;
+  gap: 0.7rem;
 }
 
-summary.tag-group-header {
-  list-style: none;
-  display: block;
+.filter-panel__inputs {
+  display: grid;
+  gap: 0.6rem;
 }
 
-summary.tag-group-header::-webkit-details-marker {
-  display: none;
+.filter-panel__search {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  padding: 0.6rem 1rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  font-size: 0.96rem;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.filter-panel__search::placeholder {
+  color: rgba(255, 255, 255, 0.58);
+}
+
+.filter-panel__search:focus {
+  background: rgba(255, 255, 255, 0.18);
+  border-color: rgba(253, 123, 197, 0.65);
+  box-shadow: 0 0 0 2px rgba(253, 123, 197, 0.28);
+  outline: none;
+}
+
+.filter-panel__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.filter-panel__clear {
+  border: none;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  color: #ffe3f7;
+  font-weight: 600;
+  padding: 0.45rem 1.1rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.filter-panel__clear:hover {
+  background: rgba(253, 123, 197, 0.32);
+  color: #fff;
+}
+
+.filter-panel__notice {
+  min-height: 1.1rem;
+  font-size: 0.78rem;
+  color: #ffd4f6;
+  letter-spacing: 0.02em;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.filter-panel__notice.visible {
+  opacity: 1;
+}
+
+.filter-panel__selected {
+  padding: 0.55rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  min-height: 48px;
+}
+
+.filter-panel__selected .selected-tag-pill {
+  background: rgba(253, 123, 197, 0.22);
+  color: #ffe9fb;
+}
+
+.filter-panel__selected .selected-tag-pill::after {
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.filter-panel__selected .selected-tags-empty {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.filter-panel__groups {
+  flex: 1;
+  overflow-y: auto;
+  padding-right: 0.35rem;
+  margin-right: -0.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.filter-panel__groups::-webkit-scrollbar {
+  width: 6px;
+}
+
+.filter-panel__groups::-webkit-scrollbar-thumb {
+  background: rgba(253, 123, 197, 0.45);
+  border-radius: 999px;
+}
+
+.filter-category {
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  padding: 0.55rem 0.7rem;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.filter-category.open {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(253, 123, 197, 0.28);
+}
+
+.filter-category__header {
+  width: 100%;
+  border: none;
+  background: none;
+  color: #ffe0f8;
+  font-weight: 600;
+  font-size: 0.98rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+  padding: 0.25rem 0;
+}
+
+.filter-category__header::after {
+  content: "\25BC";
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.7);
+  transition: transform 0.2s ease;
+}
+
+.filter-category.open .filter-category__header::after {
+  transform: rotate(180deg);
+}
+
+.filter-category__tags {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 0.55rem;
+  margin-top: 0.6rem;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.28s ease;
+}
+
+.filter-category.open .filter-category__tags {
+  max-height: 480px;
+}
+
+.filter-tag-button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 14px;
+  padding: 0.55rem 0.75rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+
+.filter-tag-button:hover {
+  background: rgba(253, 123, 197, 0.2);
+  border-color: rgba(253, 123, 197, 0.35);
+  transform: translateY(-1px);
+}
+
+.filter-tag-button.is-active {
+  background: linear-gradient(120deg, #ffd6f6 0%, #fd7bc5 100%);
+  color: #52143b;
+  border-color: rgba(253, 123, 197, 0.65);
+  box-shadow: 0 6px 18px rgba(253, 123, 197, 0.28);
+}
+
+.filter-tag-button__label {
+  flex: 1;
+  text-align: left;
+}
+
+.filter-tag-button__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.2em;
+  font-size: 0.78rem;
+  border-radius: 999px;
+  padding: 0.18rem 0.55rem;
+  background: rgba(255, 255, 255, 0.2);
+  color: inherit;
+}
+
+.filter-tag-button.is-active .filter-tag-button__count {
+  background: rgba(255, 255, 255, 0.35);
+}
+
+.filter-empty-state {
+  margin: 1rem 0 0;
+  font-size: 0.92rem;
+  color: rgba(255, 255, 255, 0.7);
+  text-align: center;
+}
+
+@media (min-width: 640px) {
+  .filter-panel__inputs {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 900px) {
+  .filter-overlay {
+    align-items: flex-start;
+    justify-content: flex-start;
+    padding: 4.5rem 0 3rem 3rem;
+  }
+  .filter-panel {
+    width: 360px;
+    max-height: calc(100vh - 6rem);
+    border-radius: 22px;
+    transform: translateX(-120%);
+  }
+  .filter-overlay.open .filter-panel {
+    transform: translateX(0);
+  }
+  .filter-panel__handle {
+    display: none;
+  }
 }
 
 /* --- Overlays & Modals --- */
@@ -1018,5 +1361,120 @@ summary.tag-group-header::-webkit-details-marker {
     padding: 0.7em 0.2em 0.7em 0.2em !important;
     min-width: 0 !important;
     min-height: 0 !important;
+  }
+}
+.prompt-suggestion-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 3, 15, 0.72);
+  backdrop-filter: blur(7px);
+  z-index: 16000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.2rem;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.25s ease, visibility 0.25s ease;
+}
+
+.prompt-suggestion-overlay.open {
+  opacity: 1;
+  visibility: visible;
+}
+
+.prompt-suggestion {
+  background: linear-gradient(160deg, rgba(45, 15, 61, 0.96) 0%, rgba(26, 8, 38, 0.94) 100%);
+  border-radius: 22px;
+  border: 1.5px solid rgba(253, 123, 197, 0.35);
+  box-shadow: 0 24px 48px rgba(7, 2, 12, 0.5);
+  width: min(520px, 95vw);
+  padding: 1.35rem 1.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.prompt-suggestion__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.prompt-suggestion__header h3 {
+  margin: 0;
+  font-size: 1.22rem;
+  color: #ffe8fb;
+  letter-spacing: 0.03em;
+}
+
+.prompt-suggestion__close {
+  border: none;
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 1.1rem;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.prompt-suggestion__close:hover {
+  background: rgba(253, 123, 197, 0.35);
+  transform: rotate(90deg);
+}
+
+.prompt-suggestion__summary {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.76);
+}
+
+.prompt-suggestion__output {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 16px;
+  padding: 0.9rem 1rem;
+  color: #ffe8fb;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  word-break: break-word;
+  min-height: 64px;
+}
+
+.prompt-suggestion__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.prompt-suggestion__copy {
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(120deg, #ffd6f6 0%, #fd7bc5 100%);
+  color: #52143b;
+  font-weight: 700;
+  padding: 0.5rem 1.2rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.prompt-suggestion__copy:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(253, 123, 197, 0.32);
+}
+
+.prompt-suggestion__copy:disabled,
+.prompt-suggestion__copy[aria-disabled="true"] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+@media (max-width: 600px) {
+  .prompt-suggestion {
+    width: min(92vw, 460px);
+    padding: 1.1rem 1.2rem;
   }
 }


### PR DESCRIPTION
## Summary
- replace the collapsed tag dropdown with a responsive filter explorer that shows live tag counts and keeps the trigger accessible on all viewports
- restyle the selected-tag chips and supporting CSS to match the new panel experience
- revive the copied-artists sidebar with selectable entries and a prompt suggestion modal that outputs top overlapping tags

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9332ae350832cbb104d9a1fed756e