### PR TITLE
Implement sticky command ribbon and stable pagination

### DIFF
--- a/docs/tailwind-rework-proposal.md
+++ b/docs/tailwind-rework-proposal.md
@@ -1,20 +1,21 @@
 # Tailwind CSS Rework Proposal
 
 ## Objectives
-- **Unify styling under Tailwind CSS** while eliminating ad-hoc global selectors and duplicated visual rules that currently live in `style.css`.
-- **Deliver a sharper, neon-glass aesthetic** aligned with the humiliation-focused moodboard in `AGENTS.md`, including Rajdhani/Inter typography, neon cyan/pink accents, and glitch-infused motion.
-- **Guarantee a "no-build" workflow** so that GitHub Pages can continue serving static files without requiring local npm scripts or CI pipelines.
-- **Improve perceived performance** by slimming CSS, reducing layout thrash, and leaning on GPU-accelerated transitions for a 60fps experience on desktop and Galaxy Z Fold4 displays.
+- **Unify all styling with Tailwind CSS (Play CDN)** so the gallery, humiliation overlays, and tag tooling share a single design language instead of ad-hoc global selectors.
+- **Deliver a pinned, neon command ribbon** that keeps the PINNED / AUDIO / GLOW / PROMPT / FILTER controls locked to the top of the viewport, paired with a feminine script "TagExplorer" wordmark to reinforce the humiliation fantasy.
+- **Stabilise gallery rendering** by paginating artists in batches of 100 pulled from `artists.json`, using infinite scroll only to fetch the next page and preventing recycled pages from looping.
+- **Improve reliability of the fullscreen viewer** with explicit Danbooru pagination and resilient fallbacks so image grids and zoom states never error out or vanish.
+- **Preserve the no-build workflow** required for GitHub Pages hosting—Tailwind must be delivered via CDN with inline configuration and optional component layers.
 
 ## Constraints & Technical Guardrails
-- Tailwind must load through the official **Play CDN** to avoid bundling (`<script src="https://cdn.tailwindcss.com?...">`).
-- Custom tokens (OKLCH palette, fonts, fold breakpoints) should live in an inline `tailwind.config = { ... }` block inside each HTML entry point, or be factored into a shared module (e.g., `scripts/tailwind-config.js`) that sets `tailwind.config` before Tailwind initializes.
-- Extended utilities or component recipes can be authored inside a `<style type="text/tailwindcss">` block using `@layer base|components|utilities`, which the CDN version parses at runtime.
-- Any bespoke CSS that Tailwind cannot express (complex keyframes, Motion One integration) stays in tiny vanilla `<style>` blocks or dedicated CSS modules imported with `<link rel="stylesheet" href="...">`.
-- Retain vanilla JS ES modules and Motion One for animation; avoid introducing build-time dependencies.
+- Tailwind loads through the official **Play CDN** only. No Vite, PostCSS, or build tooling.
+- Tailwind config must be defined before the CDN script executes. Prefer a shared module (e.g. `scripts/tailwind-config.js`) or inline `<script>` that sets `window.tailwind.config`.
+- Custom utilities/components live inside `<style type="text/tailwindcss">` blocks. Bespoke CSS (Motion One keyframes, command-ribbon polish) can sit in lean `<style>` tags or `style.css`.
+- Runtime stack remains **vanilla ES modules**, Motion One for animation, Azure whisper-only TTS with captions, and existing humiliation copy.
+- Respect Fold4 breakpoints from `AGENTS.md` (`fold-cover`, `fold-inner`) and safe-area utilities.
+- All changes must honour existing data models and JSON loading strategy.
 
-## Tailwind Integration Strategy
-
+## Tailwind Integration Plan
 ### 1. CDN Bootstrap
 ```html
 <head>
@@ -35,15 +36,16 @@
           },
           fontFamily: {
             display: ['Rajdhani', 'Orbitron', 'sans-serif'],
-            sans: ['Inter', 'system-ui', 'sans-serif']
+            sans: ['Inter', 'system-ui', 'sans-serif'],
+            script: ['Parisienne', 'cursive']
           },
           boxShadow: {
-            'neon-card': '0 20px 40px -22px rgba(8,196,255,.55)',
-            'heat-ring': '0 0 0 1px rgba(255,105,180,.4) inset, 0 12px 32px -20px rgba(255,105,180,.8)'
+            'neon-card': '0 25px 60px -25px rgba(102,243,255,.55)',
+            'heat-ring': '0 0 0 1px rgba(255,118,214,.35) inset, 0 18px 48px -30px rgba(255,118,214,.8)'
           },
           screens: {
-            'fold-cover': { 'raw': '(max-width: 520px) and (orientation: portrait)' },
-            'fold-inner': { 'raw': '(min-width: 980px) and (min-height: 980px)' }
+            'fold-cover': {'raw': '(max-width: 520px) and (orientation: portrait)'},
+            'fold-inner': {'raw': '(min-width: 980px) and (min-height: 980px)'}
           }
         }
       }
@@ -51,409 +53,76 @@
   </script>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
   <style type="text/tailwindcss">
-    @layer base {
-      html {
-        font-family: theme('fontFamily.sans');
-        background-color: theme('colors.panel');
-        color: rgb(230 230 230);
-      }
-    }
     @layer components {
-      .glass-panel {
-        @apply bg-panel/80 backdrop-blur-xl border border-accent-pink/30 shadow-heat-ring rounded-[20px];
-      }
-      .neon-card {
-        @apply glass-panel shadow-neon-card hover:shadow-accent-cyan/50 transition-shadow duration-300;
-      }
+      .command-btn {@apply control-btn px-6 py-2 tracking-[0.5em] text-white bg-accent-pink/20 border-accent-pink/40 shadow-heat-ring;}
+      .command-btn--ghost {@apply control-btn bg-white/5 border-accent-pink/20 text-slate-200;}
+      .tag-explorer-wordmark {@apply font-script text-[clamp(2.5rem,6vw,3.75rem)] text-accent-pink drop-shadow-[0_0_25px_rgba(255,118,214,0.45)];}
     }
   </style>
 </head>
 ```
-- Encapsulate the snippet above in a shared fragment (e.g., `partials/tailwind-head.html`) to avoid duplication across `/`, `/gallery/`, `/artist/`, etc.
-- Keep the CDN query string short; optional plugins (forms, typography) cover most needs without a build step.
+- Wrap the snippet in a reusable partial (e.g. `partials/tailwind-head.html`) to avoid duplication across `index.html`, future `/gallery/`, `/artist/`, etc.
+- Keep the inline config under ~8 KB; defer rarely used utilities to bespoke CSS if necessary.
 
-### 2. Replace `style.css`
-- Split the existing monolithic CSS into Tailwind utility classes applied directly in markup.
-- Migrate recurring patterns into semantic component classes inside `@layer components` (e.g., `.tag-pill`, `.toolbar`, `.humiliation-banner`).
-- Preserve keyframes for glitch/tilt in a trimmed `styles/motion.css` that only contains animation definitions and `@property` declarations not yet supported by Tailwind.
-- Remove redundant CSS variables; re-express values via Tailwind theme tokens to avoid runtime recalculation.
+### 2. Component & Utility Layers
+- Use `@layer components` for glass panels, humiliation banners, command ribbon, and fullscreen toolbar buttons.
+- Extend `@layer utilities` with helpers for sticky safe zones, `backface-visibility`, `perspective`, and `view-transition-name` for Motion One tie-ins.
+- Define typography tokens so the Parisienne script wordmark and Rajdhani headings are accessible via Tailwind classes.
 
-### 3. Shared Layout Utilities
-- Author custom utilities in `@layer utilities` for rare properties (e.g., `backface-visibility: hidden`, `perspective`, `view-transition-name`).
-- Provide `safe-area` padding helpers:
-```css
-@layer utilities {
-  .pb-safe { padding-bottom: calc(1.25rem + env(safe-area-inset-bottom)); }
-  .pt-safe { padding-top: calc(1rem + env(safe-area-inset-top)); }
-}
-```
-- Use `fold-cover:` and `fold-inner:` modifiers to tailor gallery density, filter placement, and caption layout per Fold4 mode.
+### 3. Legacy CSS Bridging
+- Trim `style.css` down to Motion One keyframes, glow halos, scrollbar styling, and the few advanced effects that Tailwind cannot express.
+- Keep humiliating overlays (taunts, JRPG bubbles) as component classes so JS modules no longer rely on brittle selectors.
+- Document any residual CSS in `styles/motion.css` with comments on why Tailwind utilities were insufficient.
 
-## Visual & Interaction System
+## Layout & Component System
+### Command Ribbon (Pinned Audio Glow Prompt Filter)
+- Sticky header with script wordmark, taunting subtitle, and a command bar containing **PINNED / AUDIO / GLOW / PROMPT / FILTER / TOP** buttons.
+- Buttons glow hotter on hover and remain reachable on Fold4 cover mode; add ghost styling for "TOP" so it reads as a secondary action.
+- IntersectionObserver toggles an `is-sticky` class once the user scrolls, intensifying the glow and border to remind them they're being watched.
 
-### Landing (`/`)
-- Structure: full-height flex column with a translucent hero card, "Enter" button, and whispering tagline.
-- Tailwind primitives: `min-h-dvh`, `flex`, `items-center`, `justify-between`, `gap-12`, `text-accent-pink`.
-- Motion: low-frequency background gradient animated using custom keyframes; "Enter" button uses Motion One on pointerenter for tilt.
+### Gallery Shell & Pagination
+- Grid uses `grid-cols-1 sm:grid-cols-2 xl:grid-cols-4` with consistent `aspect-[4/5]` media wrappers.
+- Pagination pulls **100 artists at a time** from `filtered` results. Infinite scroll merely advances `currentPage` by one and renders the next slice while guarding against duplicates via a `renderedPages` set.
+- Keep at most six pages in the DOM to avoid bloat; prune older pages while preserving scroll height for smooth continuation.
 
-### Gallery (`/gallery/`)
-- Shell: `grid` layout with responsive columns `grid-cols-1 fold-inner:grid-cols-3 md:grid-cols-2`.
-- Filters toolbar: `.toolbar` component using `@apply glass-panel sticky top-0 z-40 flex gap-3 px-4 py-2 fold-cover:pb-safe`.
-- Tag pills: `inline-flex items-center gap-2 rounded-full border border-accent-pink/40 px-4 py-2 text-sm uppercase tracking-[0.2em] hover:bg-accent-pink/20`.
-- Artist cards: `.neon-card flex flex-col gap-4 overflow-hidden` with image wrappers using `aspect-[4/5] rounded-2xl bg-panel/70` and `loading="lazy"` + `decoding="async"`.
-- Virtualization: keep the existing lazy render logic but throttle reflows with `requestAnimationFrame` batching; pre-calc card heights to prevent layout shift.
+### Fullscreen Viewer
+- Fetch Danbooru posts 40 at a time, following `order:approvals` while respecting tag limits (2 tags max).
+- Lazy render thumbnails inside the zoom modal, and load additional pages only when the sentinel comes into view.
+- Provide friendly fallbacks (`fallback.jpg`, captions, taunt overlay) when Danbooru returns no results or a fetch errors out.
 
-### Artist Profile (`/artist/:id/`)
-- Split view: `flex flex-col lg:flex-row gap-8`, with sticky metadata column on `lg:` breakpoints.
-- Stats & humiliation copy live inside `.glass-panel` sections; use `accent-heat` gradient highlights for guilt prompts.
-- Captions area: `fold-cover:fixed fold-cover:bottom-0 fold-cover:w-full` vs `fold-inner:absolute fold-inner:right-6 fold-inner:top-1/2` for large unfolded layout.
+### Filters & Humiliation Layer
+- Selected tags reside in a blurred pill rack with cumulative glow tied to tag count.
+- Random background rotation respects incognito mode (solid dark) vs glow mode (OKLCH gradients).
+- Audio and taunt banners remain accessible via keyboard and provide captions.
 
-### About / Data Pages
-- Use `prose prose-invert` from Tailwind Typography for documentation-style pages, wrapped inside `.glass-panel max-w-3xl mx-auto` containers.
+## Motion & Feedback
+- Motion One handles hover tilts, sticky taunt pulses, and command-bar glow ramps. Guard with `prefers-reduced-motion` checks.
+- Use Tailwind `group`/`group-hover` classes to trigger humiliating tooltips without extra JS.
+- Screen pulse + vibration (when supported) accentuate tag actions; provide focus-visible outlines in high-contrast pink/cyan.
 
-## Motion & Feedback Layer
-- Integrate Motion One with Tailwind's utility classes for base transforms; e.g., cards start at `transform-gpu will-change-transform` to hint at hardware acceleration.
-- Define keyframes in `styles/motion.css` (e.g., `@keyframes neonFlicker`) and trigger via Tailwind's `animate-[neonFlicker_2s_ease-in-out_infinite]` syntax.
-- Respect `prefers-reduced-motion` by wrapping Motion One triggers in `if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches)`.
-- Tailwind `group` and `group-hover` states drive humiliation tooltips and overlay transitions without extra JS listeners.
+## Performance & Accessibility
+- Artist cards lazy-load with `loading="lazy"` and prefetch on hover for the fullscreen viewer.
+- Batch count hydration so we never call Danbooru for thousands of artists at once; throttle with `setTimeout` gaps.
+- Keep header sticky but lightweight (<20 DOM nodes) so scroll performance stays at 60fps on Fold4 cover mode.
+- Announce sticky state and pagination updates via ARIA live regions (existing `#filtered-results`).
 
-## Performance & Non-Lag Considerations
-- **CSS payload**: Tailwind CDN only delivers used classes at runtime; removing `style.css` (38KB) cuts blocking CSS while still caching across pages.
-- **Layout stability**: consistent `aspect-*` utilities ensure image skeletons hold space; combine with `bg-gradient-to-br from-panel/40 via-base/20` placeholders.
-- **JS scheduling**: refactor filter updates to run inside `queueMicrotask` + `requestAnimationFrame` loops to avoid hitches when toggling many tags.
-- **Asset strategy**: adopt `loading="lazy"`, `fetchpriority="low"` on gallery images, and preconnect to Azure TTS endpoints to reduce whisper latency.
-- **Fold4 tuning**: use `fold-cover` variants to minimize simultaneous animations (only opacity/translate) while enabling full tilt/glitch on `fold-inner` and desktop.
-
-## Migration Plan
-1. **Bootstrap Tailwind** on `index.html` with CDN script + inline config; verify styling parity for hero layout.
-2. **Create component library** inside `<style type="text/tailwindcss">` covering toolbars, cards, pills, overlays, and caption containers.
-3. **Refactor markup** page-by-page, replacing `class="selected-tags-bar"` etc. with Tailwind utility strings or the new component classes.
-4. **Isolate legacy CSS**: move remaining bespoke keyframes to `styles/motion.css`, rename old `style.css` to `styles/legacy.css`, and delete once markup conversion completes.
-5. **Audit JS interactions** to align with new class hooks (e.g., query `.js-filter-pill` data attributes instead of CSS selectors that no longer exist).
-6. **Performance pass**: instrument with `performance.mark` to track filter latency, add requestAnimationFrame batching, and verify `prefers-reduced-motion` fallback.
-7. **Cross-device QA**: test Fold4 cover/inner breakpoints via Chrome device emulation; ensure safe-area utilities keep bottom navigation accessible.
-8. **Documentation update**: refresh `README.md` with Tailwind usage notes, CDN caveats, and instructions for extending theme tokens without a build.
-
-## Deliverables
-- Updated HTML pages with Tailwind utilities and shared components.
-- `scripts/tailwind-config.js` (optional) that centralizes the CDN config for reuse.
-- `styles/motion.css` containing keyframes + Motion One CSS custom properties.
-- Removal of `style.css` and replacement with Tailwind-first styling.
-- README section documenting the no-build Tailwind workflow, how to edit inline config, and guidelines for adding new components using `@layer`.
+## Migration Steps
+1. Drop in the CDN bootstrap snippet on `index.html` and ensure Tailwind utilities render correctly.
+2. Create Tailwind component classes for command ribbon, gallery cards, tag pills, and humiliation banners.
+3. Replace legacy header markup with the sticky command ribbon, wiring existing button IDs/classes so JS keeps working.
+4. Refactor gallery pagination to 100-per-page slices with a `renderedPages` guard, pruning old pages and preventing loops.
+5. Harden fullscreen viewer to fetch sequential Danbooru pages, show fallback states, and close cleanly on Escape.
+6. Remove redundant CSS from `style.css`, moving essential animations to `styles/motion.css`.
+7. Update documentation (`README.md`, this proposal) with Tailwind usage notes, CDN caveats, and how to extend the command ribbon.
+8. QA on desktop, Fold4 cover/inner, and reduced-motion contexts; confirm Azure whisper voices still initialise and captions render.
 
 ## Risks & Mitigations
-- **Runtime config size**: inline configs larger than ~10KB can slow page boot. Keep the theme extension minimal and defer non-critical utilities to bespoke CSS modules.
-- **Class name verbosity**: to maintain readability, rely on semantic component classes defined via `@layer components` for complex groups (e.g., `.gallery-toolbar`).
-- **CDN dependency**: add a `<noscript>` warning and document an offline workflow (downloaded Tailwind standalone file) should the CDN be blocked.
-- **Browser support**: ensure fallback colors use hex or RGB for browsers lacking OKLCH; Tailwind allows specifying arrays like `['oklch(...)', '#0f0b1b']` for safety.
+- **Runtime config bloat**: keep Tailwind `extend` minimal; rely on component classes instead of long utility chains in markup.
+- **CDN outage**: document a fallback (downloaded Tailwind standalone) and show a soft warning if CDN fails.
+- **Sticky header overlap**: reserve space with padding on the main container and test on small screens to avoid content jumping under the command bar.
+- **Danbooru rate limits**: paginate API calls, reuse sessionStorage caches, and handle empty responses gracefully.
 
-## Next Steps
-- Approve this proposal.
-- Schedule implementation sprints (estimated 2–3 passes: core shell, gallery/artist pages, humiliation + motion polish).
-- Begin refactoring with automated visual regression snapshots (Playwright `page.screenshot`) to confirm parity after each page migration.
-# Tailwind CSS Rework Proposal
-
-## Objectives
-- **Unify styling under Tailwind CSS** while eliminating ad-hoc global selectors and duplicated visual rules that currently live in `style.css`.
-- **Deliver a sharper, neon-glass aesthetic** aligned with the humiliation-focused moodboard in `AGENTS.md`, including Rajdhani/Inter typography, neon cyan/pink accents, and glitch-infused motion.
-- **Guarantee a "no-build" workflow** so that GitHub Pages can continue serving static files without requiring local npm scripts or CI pipelines.
-- **Improve perceived performance** by slimming CSS, reducing layout thrash, and leaning on GPU-accelerated transitions for a 60fps experience on desktop and Galaxy Z Fold4 displays.
-
-## Constraints & Technical Guardrails
-- Tailwind must load through the official **Play CDN** to avoid bundling (`<script src="https://cdn.tailwindcss.com?...">`).
-- Custom tokens (OKLCH palette, fonts, fold breakpoints) should live in an inline `tailwind.config = { ... }` block inside each HTML entry point, or be factored into a shared module (e.g., `scripts/tailwind-config.js`) that sets `tailwind.config` before Tailwind initializes.
-- Extended utilities or component recipes can be authored inside a `<style type="text/tailwindcss">` block using `@layer base|components|utilities`, which the CDN version parses at runtime.
-- Any bespoke CSS that Tailwind cannot express (complex keyframes, Motion One integration) stays in tiny vanilla `<style>` blocks or dedicated CSS modules imported with `<link rel="stylesheet" href="...">`.
-- Retain vanilla JS ES modules and Motion One for animation; avoid introducing build-time dependencies.
-
-## Tailwind Integration Strategy
-
-### 1. CDN Bootstrap
-```html
-<head>
-  <script>
-    window.tailwind = window.tailwind || {};
-    window.tailwind.config = {
-      darkMode: 'class',
-      theme: {
-        extend: {
-          colors: {
-            base: 'oklch(0.1 0.02 260)',
-            panel: 'oklch(0.19 0.02 260)',
-            accent: {
-              cyan: 'oklch(0.8 0.14 205)',
-              pink: 'oklch(0.8 0.18 350)',
-              heat: 'oklch(0.66 0.25 25)'
-            }
-          },
-          fontFamily: {
-            display: ['Rajdhani', 'Orbitron', 'sans-serif'],
-            ui: ['Inter', 'system-ui', 'sans-serif']
-          },
-          boxShadow: {
-            'neon-card': '0 20px 40px -22px rgba(8,196,255,.55)',
-            'heat-ring': '0 0 0 1px rgba(255,105,180,.4) inset, 0 12px 32px -20px rgba(255,105,180,.8)'
-          },
-          screens: {
-            'fold-cover': { 'raw': '(max-width: 520px) and (orientation: portrait)' },
-            'fold-inner': { 'raw': '(min-width: 980px) and (min-height: 980px)' }
-          }
-        }
-      }
-    };
-  </script>
-  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <style type="text/tailwindcss">
-    @layer base {
-      html {
-        font-family: theme('fontFamily.sans');
-        background-color: theme('colors.panel');
-        color: rgb(230 230 230);
-      }
-    }
-    @layer components {
-      .glass-panel {
-        @apply bg-panel/80 backdrop-blur-xl border border-accent-pink/30 shadow-heat-ring rounded-[20px];
-      }
-      .neon-card {
-        @apply glass-panel shadow-neon-card hover:shadow-accent-cyan/50 transition-shadow duration-300;
-      }
-    }
-  </style>
-</head>
-```
-- Encapsulate the snippet above in a shared fragment (e.g., `partials/tailwind-head.html`) to avoid duplication across `/`, `/gallery/`, `/artist/`, etc.
-- Keep the CDN query string short; optional plugins (forms, typography) cover most needs without a build step.
-
-### 2. Replace `style.css`
-- Split the existing monolithic CSS into Tailwind utility classes applied directly in markup.
-- Migrate recurring patterns into semantic component classes inside `@layer components` (e.g., `.tag-pill`, `.toolbar`, `.humiliation-banner`).
-- Preserve keyframes for glitch/tilt in a trimmed `styles/motion.css` that only contains animation definitions and `@property` declarations not yet supported by Tailwind.
-- Remove redundant CSS variables; re-express values via Tailwind theme tokens to avoid runtime recalculation.
-
-### 3. Shared Layout Utilities
-- Author custom utilities in `@layer utilities` for rare properties (e.g., `backface-visibility: hidden`, `perspective`, `view-transition-name`).
-- Provide `safe-area` padding helpers:
-```css
-@layer utilities {
-  .pb-safe { padding-bottom: calc(1.25rem + env(safe-area-inset-bottom)); }
-  .pt-safe { padding-top: calc(1rem + env(safe-area-inset-top)); }
-}
-```
-- Use `fold-cover:` and `fold-inner:` modifiers to tailor gallery density, filter placement, and caption layout per Fold4 mode.
-
-## Visual & Interaction System
-
-### Landing (`/`)
-- Structure: full-height flex column with a translucent hero card, "Enter" button, and whispering tagline.
-- Tailwind primitives: `min-h-dvh`, `flex`, `items-center`, `justify-between`, `gap-12`, `text-accent-pink`.
-- Motion: low-frequency background gradient animated using custom keyframes; "Enter" button uses Motion One on pointerenter for tilt.
-
-### Gallery (`/gallery/`)
-- Shell: `grid` layout with responsive columns `grid-cols-1 fold-inner:grid-cols-3 md:grid-cols-2`.
-- Filters toolbar: `.toolbar` component using `@apply glass-panel sticky top-0 z-40 flex gap-3 px-4 py-2 fold-cover:pb-safe`.
-- Tag pills: `inline-flex items-center gap-2 rounded-full border border-accent-pink/40 px-4 py-2 text-sm uppercase tracking-[0.2em] hover:bg-accent-pink/20`.
-- Artist cards: `.neon-card flex flex-col gap-4 overflow-hidden` with image wrappers using `aspect-[4/5] rounded-2xl bg-panel/70` and `loading="lazy"` + `decoding="async"`.
-- Virtualization: keep the existing lazy render logic but throttle reflows with `requestAnimationFrame` batching; pre-calc card heights to prevent layout shift.
-
-### Artist Profile (`/artist/:id/`)
-- Split view: `flex flex-col lg:flex-row gap-8`, with sticky metadata column on `lg:` breakpoints.
-- Stats & humiliation copy live inside `.glass-panel` sections; use `accent-heat` gradient highlights for guilt prompts.
-- Captions area: `fold-cover:fixed fold-cover:bottom-0 fold-cover:w-full` vs `fold-inner:absolute fold-inner:right-6 fold-inner:top-1/2` for large unfolded layout.
-
-### About / Data Pages
-- Use `prose prose-invert` from Tailwind Typography for documentation-style pages, wrapped inside `.glass-panel max-w-3xl mx-auto` containers.
-
-## Motion & Feedback Layer
-- Integrate Motion One with Tailwind's utility classes for base transforms; e.g., cards start at `transform-gpu will-change-transform` to hint at hardware acceleration.
-- Define keyframes in `styles/motion.css` (e.g., `@keyframes neonFlicker`) and trigger via Tailwind's `animate-[neonFlicker_2s_ease-in-out_infinite]` syntax.
-- Respect `prefers-reduced-motion` by wrapping Motion One triggers in `if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches)`.
-- Tailwind `group` and `group-hover` states drive humiliation tooltips and overlay transitions without extra JS listeners.
-
-## Performance & Non-Lag Considerations
-- **CSS payload**: Tailwind CDN only delivers used classes at runtime; removing `style.css` (38KB) cuts blocking CSS while still caching across pages.
-- **Layout stability**: consistent `aspect-*` utilities ensure image skeletons hold space; combine with `bg-gradient-to-br from-panel/40 via-base/20` placeholders.
-- **JS scheduling**: refactor filter updates to run inside `queueMicrotask` + `requestAnimationFrame` loops to avoid hitches when toggling many tags.
-- **Asset strategy**: adopt `loading="lazy"`, `fetchpriority="low"` on gallery images, and preconnect to Azure TTS endpoints to reduce whisper latency.
-- **Fold4 tuning**: use `fold-cover` variants to minimize simultaneous animations (only opacity/translate) while enabling full tilt/glitch on `fold-inner` and desktop.
-
-## Migration Plan
-1. **Bootstrap Tailwind** on `index.html` with CDN script + inline config; verify styling parity for hero layout.
-2. **Create component library** inside `<style type="text/tailwindcss">` covering toolbars, cards, pills, overlays, and caption containers.
-3. **Refactor markup** page-by-page, replacing `class="selected-tags-bar"` etc. with Tailwind utility strings or the new component classes.
-4. **Isolate legacy CSS**: move remaining bespoke keyframes to `styles/motion.css`, rename old `style.css` to `styles/legacy.css`, and delete once markup conversion completes.
-5. **Audit JS interactions** to align with new class hooks (e.g., query `.js-filter-pill` data attributes instead of CSS selectors that no longer exist).
-6. **Performance pass**: instrument with `performance.mark` to track filter latency, add requestAnimationFrame batching, and verify `prefers-reduced-motion` fallback.
-7. **Cross-device QA**: test Fold4 cover/inner breakpoints via Chrome device emulation; ensure safe-area utilities keep bottom navigation accessible.
-8. **Documentation update**: refresh `README.md` with Tailwind usage notes, CDN caveats, and instructions for extending theme tokens without a build.
-
-## Deliverables
-- Updated HTML pages with Tailwind utilities and shared components.
-- `scripts/tailwind-config.js` (optional) that centralizes the CDN config for reuse.
-- `styles/motion.css` containing keyframes + Motion One CSS custom properties.
-- Removal of `style.css` and replacement with Tailwind-first styling.
-- README section documenting the no-build Tailwind workflow, how to edit inline config, and guidelines for adding new components using `@layer`.
-
-## Risks & Mitigations
-- **Runtime config size**: inline configs larger than ~10KB can slow page boot. Keep the theme extension minimal and defer non-critical utilities to bespoke CSS modules.
-- **Class name verbosity**: to maintain readability, rely on semantic component classes defined via `@layer components` for complex groups (e.g., `.gallery-toolbar`).
-- **CDN dependency**: add a `<noscript>` warning and document an offline workflow (downloaded Tailwind standalone file) should the CDN be blocked.
-- **Browser support**: ensure fallback colors use hex or RGB for browsers lacking OKLCH; Tailwind allows specifying arrays like `['oklch(...)', '#0f0b1b']` for safety.
-
-## Next Steps
-- Approve this proposal.
-- Schedule implementation sprints (estimated 2–3 passes: core shell, gallery/artist pages, humiliation + motion polish).
-- Begin refactoring with automated visual regression snapshots (Playwright `page.screenshot`) to confirm parity after each page migration.
-# Tailwind CSS Rework Proposal
-
-## Objectives
-- **Unify styling under Tailwind CSS** while eliminating ad-hoc global selectors and duplicated visual rules that currently live in `style.css`.
-- **Deliver a sharper, neon-glass aesthetic** aligned with the humiliation-focused moodboard in `AGENTS.md`, including Rajdhani/Inter typography, neon cyan/pink accents, and glitch-infused motion.
-- **Guarantee a "no-build" workflow** so that GitHub Pages can continue serving static files without requiring local npm scripts or CI pipelines.
-- **Improve perceived performance** by slimming CSS, reducing layout thrash, and leaning on GPU-accelerated transitions for a 60fps experience on desktop and Galaxy Z Fold4 displays.
-
-## Constraints & Technical Guardrails
-- Tailwind must load through the official **Play CDN** to avoid bundling (`<script src="https://cdn.tailwindcss.com?...">`).
-- Custom tokens (OKLCH palette, fonts, fold breakpoints) should live in an inline `tailwind.config = { ... }` block inside each HTML entry point, or be factored into a shared module (e.g., `scripts/tailwind-config.js`) that sets `tailwind.config` before Tailwind initializes.
-- Extended utilities or component recipes can be authored inside a `<style type="text/tailwindcss">` block using `@layer base|components|utilities`, which the CDN version parses at runtime.
-- Any bespoke CSS that Tailwind cannot express (complex keyframes, Motion One integration) stays in tiny vanilla `<style>` blocks or dedicated CSS modules imported with `<link rel="stylesheet" href="...">`.
-- Retain vanilla JS ES modules and Motion One for animation; avoid introducing build-time dependencies.
-
-## Tailwind Integration Strategy
-
-### 1. CDN Bootstrap
-```html
-<head>
-  <script>
-    window.tailwind = window.tailwind || {};
-    window.tailwind.config = {
-      darkMode: 'class',
-      theme: {
-        extend: {
-          colors: {
-            base: 'oklch(0.1 0.02 260)',
-            panel: 'oklch(0.19 0.02 260)',
-            accent: {
-              cyan: 'oklch(0.8 0.14 205)',
-              pink: 'oklch(0.8 0.18 350)',
-              heat: 'oklch(0.66 0.25 25)'
-            }
-          },
-          fontFamily: {
-            display: ['Rajdhani', 'Orbitron', 'sans-serif'],
-            ui: ['Inter', 'system-ui', 'sans-serif']
-          },
-          boxShadow: {
-            'neon-card': '0 20px 40px -22px rgba(8,196,255,.55)',
-            'heat-ring': '0 0 0 1px rgba(255,105,180,.4) inset, 0 12px 32px -20px rgba(255,105,180,.8)'
-          },
-          screens: {
-            'fold-cover': { 'raw': '(max-width: 520px) and (orientation: portrait)' },
-            'fold-inner': { 'raw': '(min-width: 980px) and (min-height: 980px)' }
-          }
-        }
-      }
-    };
-  </script>
-  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <style type="text/tailwindcss">
-    @layer base {
-      html {
-        font-family: theme('fontFamily.sans');
-        background-color: theme('colors.panel');
-        color: rgb(230 230 230);
-      }
-    }
-    @layer components {
-      .glass-panel {
-        @apply bg-panel/80 backdrop-blur-xl border border-accent-pink/30 shadow-heat-ring rounded-[20px];
-      }
-      .neon-card {
-        @apply glass-panel shadow-neon-card hover:shadow-accent-cyan/50 transition-shadow duration-300;
-      }
-    }
-  </style>
-</head>
-```
-- Encapsulate the snippet above in a shared fragment (e.g., `partials/tailwind-head.html`) to avoid duplication across `/`, `/gallery/`, `/artist/`, etc.
-- Keep the CDN query string short; optional plugins (forms, typography) cover most needs without a build step.
-
-### 2. Replace `style.css`
-- Split the existing monolithic CSS into Tailwind utility classes applied directly in markup.
-- Migrate recurring patterns into semantic component classes inside `@layer components` (e.g., `.tag-pill`, `.toolbar`, `.humiliation-banner`).
-- Preserve keyframes for glitch/tilt in a trimmed `styles/motion.css` that only contains animation definitions and `@property` declarations not yet supported by Tailwind.
-- Remove redundant CSS variables; re-express values via Tailwind theme tokens to avoid runtime recalculation.
-
-### 3. Shared Layout Utilities
-- Author custom utilities in `@layer utilities` for rare properties (e.g., `backface-visibility: hidden`, `perspective`, `view-transition-name`).
-- Provide `safe-area` padding helpers:
-```css
-@layer utilities {
-  .pb-safe { padding-bottom: calc(1.25rem + env(safe-area-inset-bottom)); }
-  .pt-safe { padding-top: calc(1rem + env(safe-area-inset-top)); }
-}
-```
-- Use `fold-cover:` and `fold-inner:` modifiers to tailor gallery density, filter placement, and caption layout per Fold4 mode.
-
-## Visual & Interaction System
-
-### Landing (`/`)
-- Structure: full-height flex column with a translucent hero card, "Enter" button, and whispering tagline.
-- Tailwind primitives: `min-h-dvh`, `flex`, `items-center`, `justify-between`, `gap-12`, `text-accent-pink`.
-- Motion: low-frequency background gradient animated using custom keyframes; "Enter" button uses Motion One on pointerenter for tilt.
-
-### Gallery (`/gallery/`)
-- Shell: `grid` layout with responsive columns `grid-cols-1 fold-inner:grid-cols-3 md:grid-cols-2`.
-- Filters toolbar: `.toolbar` component using `@apply glass-panel sticky top-0 z-40 flex gap-3 px-4 py-2 fold-cover:pb-safe`.
-- Tag pills: `inline-flex items-center gap-2 rounded-full border border-accent-pink/40 px-4 py-2 text-sm uppercase tracking-[0.2em] hover:bg-accent-pink/20`.
-- Artist cards: `.neon-card flex flex-col gap-4 overflow-hidden` with image wrappers using `aspect-[4/5] rounded-2xl bg-panel/70` and `loading="lazy"` + `decoding="async"`.
-- Virtualization: keep the existing lazy render logic but throttle reflows with `requestAnimationFrame` batching; pre-calc card heights to prevent layout shift.
-
-### Artist Profile (`/artist/:id/`)
-- Split view: `flex flex-col lg:flex-row gap-8`, with sticky metadata column on `lg:` breakpoints.
-- Stats & humiliation copy live inside `.glass-panel` sections; use `accent-heat` gradient highlights for guilt prompts.
-- Captions area: `fold-cover:fixed fold-cover:bottom-0 fold-cover:w-full` vs `fold-inner:absolute fold-inner:right-6 fold-inner:top-1/2` for large unfolded layout.
-
-### About / Data Pages
-- Use `prose prose-invert` from Tailwind Typography for documentation-style pages, wrapped inside `.glass-panel max-w-3xl mx-auto` containers.
-
-## Motion & Feedback Layer
-- Integrate Motion One with Tailwind's utility classes for base transforms; e.g., cards start at `transform-gpu will-change-transform` to hint at hardware acceleration.
-- Define keyframes in `styles/motion.css` (e.g., `@keyframes neonFlicker`) and trigger via Tailwind's `animate-[neonFlicker_2s_ease-in-out_infinite]` syntax.
-- Respect `prefers-reduced-motion` by wrapping Motion One triggers in `if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches)`.
-- Tailwind `group` and `group-hover` states drive humiliation tooltips and overlay transitions without extra JS listeners.
-
-## Performance & Non-Lag Considerations
-- **CSS payload**: Tailwind CDN only delivers used classes at runtime; removing `style.css` (38KB) cuts blocking CSS while still caching across pages.
-- **Layout stability**: consistent `aspect-*` utilities ensure image skeletons hold space; combine with `bg-gradient-to-br from-panel/40 via-base/20` placeholders.
-- **JS scheduling**: refactor filter updates to run inside `queueMicrotask` + `requestAnimationFrame` loops to avoid hitches when toggling many tags.
-- **Asset strategy**: adopt `loading="lazy"`, `fetchpriority="low"` on gallery images, and preconnect to Azure TTS endpoints to reduce whisper latency.
-- **Fold4 tuning**: use `fold-cover` variants to minimize simultaneous animations (only opacity/translate) while enabling full tilt/glitch on `fold-inner` and desktop.
-
-## Migration Plan
-1. **Bootstrap Tailwind** on `index.html` with CDN script + inline config; verify styling parity for hero layout.
-2. **Create component library** inside `<style type="text/tailwindcss">` covering toolbars, cards, pills, overlays, and caption containers.
-3. **Refactor markup** page-by-page, replacing `class="selected-tags-bar"` etc. with Tailwind utility strings or the new component classes.
-4. **Isolate legacy CSS**: move remaining bespoke keyframes to `styles/motion.css`, rename old `style.css` to `styles/legacy.css`, and delete once markup conversion completes.
-5. **Audit JS interactions** to align with new class hooks (e.g., query `.js-filter-pill` data attributes instead of CSS selectors that no longer exist).
-6. **Performance pass**: instrument with `performance.mark` to track filter latency, add requestAnimationFrame batching, and verify `prefers-reduced-motion` fallback.
-7. **Cross-device QA**: test Fold4 cover/inner breakpoints via Chrome device emulation; ensure safe-area utilities keep bottom navigation accessible.
-8. **Documentation update**: refresh `README.md` with Tailwind usage notes, CDN caveats, and instructions for extending theme tokens without a build.
-
-## Deliverables
-- Updated HTML pages with Tailwind utilities and shared components.
-- `scripts/tailwind-config.js` (optional) that centralizes the CDN config for reuse.
-- `styles/motion.css` containing keyframes + Motion One CSS custom properties.
-- Removal of `style.css` and replacement with Tailwind-first styling.
-- README section documenting the no-build Tailwind workflow, how to edit inline config, and guidelines for adding new components using `@layer`.
-
-## Risks & Mitigations
-- **Runtime config size**: inline configs larger than ~10KB can slow page boot. Keep the theme extension minimal and defer non-critical utilities to bespoke CSS modules.
-- **Class name verbosity**: to maintain readability, rely on semantic component classes defined via `@layer components` for complex groups (e.g., `.gallery-toolbar`).
-- **CDN dependency**: add a `<noscript>` warning and document an offline workflow (downloaded Tailwind standalone file) should the CDN be blocked.
-- **Browser support**: ensure fallback colors use hex or RGB for browsers lacking OKLCH; Tailwind allows specifying arrays like `['oklch(...)', '#0f0b1b']` for safety.
-
-## Next Steps
-- Approve this proposal.
-- Schedule implementation sprints (estimated 2–3 passes: core shell, gallery/artist pages, humiliation + motion polish).
-- Begin refactoring with automated visual regression snapshots (Playwright `page.screenshot`) to confirm parity after each page migration.
+## Approval & Next Steps
+- Approve this proposal to greenlight the Tailwind refactor.
+- Schedule implementation in two passes: (1) layout + command ribbon + pagination fixes, (2) fullscreen viewer polish + humiliation overlays.
+- After implementation, capture visual snapshots (Playwright `page.screenshot`) to confirm the sticky command ribbon and pagination behave as designed.

--- a/index.html
+++ b/index.html
@@ -8,33 +8,38 @@
   <link rel="icon" type="image/png" href="favicon.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Rajdhani:wght@600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Parisienne&family=Rajdhani:wght@600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="relative min-h-screen overflow-x-hidden">
   <div id="background-blur" class="background-lattice" aria-hidden="true"></div>
   <div class="relative z-10 flex min-h-screen flex-col">
     <header class="top-surface">
-      <div class="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 pb-10 pt-12 lg:flex-row lg:items-end lg:justify-between">
-        <div class="space-y-5">
-          <span class="brand-chip">TagExplorer</span>
-          <h1 class="text-4xl font-display uppercase tracking-[0.55em] text-white drop-shadow-[0_8px_35px_rgba(102,243,255,0.35)] sm:text-5xl">Artist Gallery</h1>
-          <p id="tagline" class="max-w-xl text-sm uppercase tracking-[0.3em] text-slate-300">Pathetic..~</p>
-        </div>
-        <div class="flex flex-wrap items-center gap-3">
-          <button class="control-btn sidebar-toggle" type="button">Pinned</button>
-          <button class="control-btn audio-toggle" type="button">Audio</button>
-          <button class="control-btn theme-toggle" type="button">Glow</button>
-          <button id="back-to-top" class="control-btn" type="button" aria-label="Back to top">Top</button>
+      <div class="mx-auto w-full max-w-7xl px-6 pb-8 pt-12">
+        <div class="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+          <div class="space-y-4">
+            <span class="tag-explorer-wordmark">TagExplorer</span>
+            <h1 class="gallery-title text-4xl font-display uppercase tracking-[0.55em] text-white drop-shadow-[0_8px_35px_rgba(102,243,255,0.35)] sm:text-5xl">Artist Gallery</h1>
+            <p id="tagline" class="max-w-xl text-sm uppercase tracking-[0.3em] text-slate-300">Pathetic..~</p>
+          </div>
+          <p class="top-bar-tease max-w-sm text-xs uppercase tracking-[0.35em] text-rose-200/80 lg:text-right">
+            I'll keep the glow pinned above every scroll so you can't pretend you're not begging for more.
+          </p>
         </div>
       </div>
       <div class="surface-divider"></div>
-      <nav id="tag-explorer-bar" class="mx-auto flex w-full max-w-7xl items-center gap-3 px-6 pb-8">
-        <button id="prompts-btn" class="bar-btn" type="button">Prompts</button>
-        <button id="filters-btn" class="bar-btn" type="button" aria-haspopup="dialog" aria-expanded="false" aria-controls="tag-filter-panel">Filters</button>
-        <div class="ml-auto flex items-center gap-3 text-[0.55rem] uppercase tracking-[0.4em] text-slate-500">
-          <span class="hidden fold-cover:inline">Cover Mode</span>
-          <span class="hidden fold-inner:inline">Inner Mode</span>
+      <nav id="tag-explorer-bar" class="command-bar mx-auto w-full max-w-7xl px-6 pb-6 pt-4" role="toolbar" aria-label="Pinned humiliation controls">
+        <div class="command-group" role="group" aria-label="Primary gallery controls">
+          <button class="control-btn command-btn sidebar-toggle" type="button">PINNED</button>
+          <button class="control-btn command-btn audio-toggle" type="button">AUDIO</button>
+          <button class="control-btn command-btn theme-toggle" type="button">GLOW</button>
+          <button id="prompts-btn" class="control-btn command-btn" type="button">PROMPT</button>
+          <button id="filters-btn" class="control-btn command-btn" type="button" aria-haspopup="dialog" aria-expanded="false" aria-controls="tag-filter-panel">FILTER</button>
+        </div>
+        <div class="command-status">
+          <span class="hidden fold-cover:inline">COVER MODE</span>
+          <span class="hidden fold-inner:inline">INNER MODE</span>
+          <button id="back-to-top" class="control-btn command-btn command-btn--ghost" type="button" aria-label="Back to top">TOP</button>
         </div>
       </nav>
     </header>

--- a/main.js
+++ b/main.js
@@ -252,7 +252,6 @@ const sortButtonElem = document.getElementById("sort-button");
 if (sortButtonElem && sortSelect) {
   sortButtonElem.addEventListener("click", () => {
     setSortMode(sortSelect.value);
-    forceSortAndRender();
   });
 }
 

--- a/modules/gallery.js
+++ b/modules/gallery.js
@@ -19,7 +19,7 @@ function getThumbnailUrl(artist) {
  */
 
 // Gallery state
-const DEFAULT_ARTISTS_PER_PAGE = 36;
+const DEFAULT_ARTISTS_PER_PAGE = 100;
 const MAX_PAGES_IN_DOM = 6;
 
 let filtered = [];
@@ -28,13 +28,21 @@ let sortMode = "name";
 let filterGeneration = 0;
 let artistsPerPage = DEFAULT_ARTISTS_PER_PAGE;
 let currentPage = 1;
+const renderedPages = new Set();
 
 function getCurrentPage() {
   return currentPage;
 }
 
+function getTotalPages() {
+  if (!artistsPerPage) return 0;
+  return Math.ceil(filtered.length / artistsPerPage);
+}
+
 function setCurrentPage(val) {
-  currentPage = Math.max(1, val);
+  const totalPages = getTotalPages();
+  const maxPage = totalPages > 0 ? totalPages : 1;
+  currentPage = Math.min(Math.max(1, val), maxPage);
 }
 
 // DOM references
@@ -63,6 +71,29 @@ function ensureGallerySentinel() {
     artistGallery.appendChild(gallerySentinel);
   }
   return gallerySentinel;
+}
+
+function removeCardsForPage(page) {
+  if (!artistGallery) return;
+  const cards = artistGallery.querySelectorAll(
+    `.artist-card[data-page="${page}"]`
+  );
+  cards.forEach((card) => card.remove());
+}
+
+function sortFilteredArtists() {
+  if (!filtered.length) return;
+  if (sortMode === "count") {
+    filtered.sort(
+      (a, b) => (b._totalImageCount || 0) - (a._totalImageCount || 0)
+    );
+  } else {
+    filtered.sort((a, b) =>
+      a.artistName.localeCompare(b.artistName, undefined, {
+        sensitivity: "base",
+      })
+    );
+  }
 }
 
 /**
@@ -496,27 +527,42 @@ function getFilteredArtists() {
 function setArtistsPerPage(count) {
   artistsPerPage = Math.max(10, count);
   setCurrentPage(1);
-  renderArtistsPage();
+  renderArtistsPage({ force: true });
 }
 
 /**
  * Renders the current page of artists, with pagination.
  */
-function renderArtistsPage() {
+function renderArtistsPage(options = {}) {
+  if (!artistGallery) return;
+  const { force = false } = options;
   const page = getCurrentPage();
   const start = (page - 1) * artistsPerPage;
-  const end = start + artistsPerPage;
-  const artistsToShow = filtered.slice(start, end);
 
-  // Only clear gallery if this is the first page (reset)
   if (page === 1) {
     artistGallery.innerHTML = "";
     resetGallerySentinel();
+    renderedPages.clear();
+  } else if (force) {
+    removeCardsForPage(page);
+    renderedPages.delete(page);
+  } else if (renderedPages.has(page)) {
+    pruneGalleryPages(page);
+    return;
   }
 
+  if (start >= filtered.length) {
+    ensureGallerySentinel();
+    pruneGalleryPages(page);
+    return;
+  }
+
+  const end = Math.min(start + artistsPerPage, filtered.length);
+  const artistsToShow = filtered.slice(start, end);
+
   if (artistsToShow.length > 0) {
-    // Always append new artist cards for each page
     renderArtistCards(artistsToShow, undefined, page);
+    renderedPages.add(page);
   } else {
     ensureGallerySentinel();
   }
@@ -672,24 +718,29 @@ function pruneGalleryPages(currentPage) {
   if (!artistGallery) return;
   const minimumPage = Math.max(1, currentPage - (MAX_PAGES_IN_DOM - 1));
   const cards = artistGallery.querySelectorAll(".artist-card[data-page]");
+  const pagesRemoved = new Set();
   cards.forEach((card) => {
     const pageValue = parseInt(card.getAttribute("data-page") || "", 10);
     if (!Number.isNaN(pageValue) && pageValue < minimumPage) {
       card.remove();
+      pagesRemoved.add(pageValue);
     }
   });
+  pagesRemoved.forEach((page) => renderedPages.delete(page));
 }
 
 function getPaginationInfo() {
   const page = getCurrentPage();
   const total = filtered.length;
+  const totalPages = getTotalPages();
   const shown = Math.min(page * artistsPerPage, total);
   return {
     total: total,
     shown: shown,
-    hasMore: shown < total,
+    hasMore: page < totalPages,
     currentPage: page,
-    artistsPerPage: artistsPerPage
+    artistsPerPage: artistsPerPage,
+    totalPages,
   };
 }
 
@@ -713,6 +764,7 @@ async function filterArtists(reset = true, force = false) {
       setCurrentPage(1);
       artistGallery.innerHTML = "";
       resetGallerySentinel();
+      renderedPages.clear();
     }
 
     spinner = artistGallery.querySelector(".gallery-spinner");
@@ -753,6 +805,8 @@ async function filterArtists(reset = true, force = false) {
     if (spinner.setTotal) spinner.setTotal(filtered.length);
     if (spinner.updateProgress) spinner.updateProgress(0);
 
+    sortFilteredArtists();
+
     // Always fetch counts for the current filtered artists
     async function fetchInBatches(
       artists,
@@ -786,11 +840,11 @@ async function filterArtists(reset = true, force = false) {
 
       if (gen !== filterGeneration) return;
 
-      setSortMode(sortMode);
-      renderArtistsPage();
+      sortFilteredArtists();
+      renderArtistsPage({ force: true });
     }
 
-    renderArtistsPage(); // Render immediately
+    renderArtistsPage({ force: true }); // Render immediately
 
     if (reset) {
       await fetchInBatches(filtered, 5, 1000, generation, spinner).catch(
@@ -799,13 +853,13 @@ async function filterArtists(reset = true, force = false) {
         }
       );
       if (generation !== filterGeneration) return;
-      setSortMode(sortMode);
-      renderArtistsPage();
+      sortFilteredArtists();
+      renderArtistsPage({ force: true });
     } else if (force) {
       fetchInBatches(filtered, 5, 1000, generation, spinner).then(() => {
         if (generation !== filterGeneration) return;
-        setSortMode(sortMode);
-        renderArtistsPage();
+        sortFilteredArtists();
+        renderArtistsPage({ force: true });
       });
     }
   } catch (error) {
@@ -834,28 +888,24 @@ function initGallery() {
   }
 }
 
-  function setSortMode(mode) {
-    sortMode = mode;
-    lastSortMode = mode;
-    if (filtered.length > 0) {
-      if (sortMode === "count") {
-        filtered.sort(
-          (a, b) => (b._totalImageCount || 0) - (a._totalImageCount || 0)
-        );
-      } else {
-        filtered.sort((a, b) =>
-          a.artistName.localeCompare(b.artistName, undefined, {
-            sensitivity: "base",
-          })
-        );
-      }
-      renderArtistsPage();
-    }
+function setSortMode(mode, options = {}) {
+  const { preservePage = false, deferRender = false } = options;
+  sortMode = mode;
+  lastSortMode = mode;
+  sortFilteredArtists();
+  if (!preservePage) {
+    setCurrentPage(1);
   }
+  if (!deferRender) {
+    renderArtistsPage({ force: true });
+  }
+}
 
 function forceSortAndRender() {
-  if (lastSortMode) sortMode = lastSortMode;
-  renderArtistsPage();
+  if (lastSortMode) {
+    setSortMode(lastSortMode, { preservePage: true, deferRender: true });
+  }
+  renderArtistsPage({ force: true });
 }
 
 
@@ -875,7 +925,9 @@ function setGetArtistNameFilterCallback(callback) {
 }
 
 function setSortPreference(preference) {
-  sortMode = preference === "count" ? "count" : "name";
+  const mode = preference === "count" ? "count" : "name";
+  if (mode === sortMode) return;
+  setSortMode(mode);
 }
 
 

--- a/modules/ui.js
+++ b/modules/ui.js
@@ -99,6 +99,31 @@ function setupBackToTop() {
   });
 }
 
+function setupStickyTopBar() {
+  const header = document.querySelector(".top-surface");
+  if (!header) return;
+
+  let ticking = false;
+  const update = () => {
+    const shouldStick = window.scrollY > 32;
+    header.classList.toggle("is-sticky", shouldStick);
+    ticking = false;
+  };
+
+  const onScroll = () => {
+    if (!ticking) {
+      window.requestAnimationFrame(update);
+      ticking = true;
+    }
+  };
+
+  update();
+  window.addEventListener("scroll", onScroll, { passive: true });
+  window.addEventListener("beforeunload", () => {
+    window.removeEventListener("scroll", onScroll);
+  });
+}
+
 /**
  * Sets up random background changes at intervals
  */
@@ -370,6 +395,7 @@ function initUI() {
   }
   addLipstickKiss();
   setupBackToTop();
+  setupStickyTopBar();
 }
 
 /**

--- a/style.css
+++ b/style.css
@@ -501,7 +501,9 @@ body.incognito-theme .background-lattice {
 }
 
 .top-surface {
-    position: relative;
+    position: sticky;
+    top: 0;
+    z-index: 60;
     overflow: hidden;
     border-bottom-width: 1px;
     border-color: hsla(0, 0%, 100%, .05);
@@ -2516,5 +2518,132 @@ body.sidebar-open .sidebar-wrapper {
 @media (min-width:980px) and (min-height:980px) {
     .fold-inner\:inline {
         display: inline
+    }
+}
+
+/* --- Sticky humiliation top bar enhancements --- */
+.top-surface {
+    transition: background-color .35s cubic-bezier(.4,-.2,.2,1.2),
+        box-shadow .35s cubic-bezier(.4,-.2,.2,1.2),
+        border-color .35s cubic-bezier(.4,-.2,.2,1.2);
+}
+
+.top-surface.is-sticky {
+    background-color: rgba(22, 21, 37, .95);
+    border-color: rgba(255, 118, 214, .3);
+    box-shadow: 0 24px 60px -28px rgba(255, 118, 214, .55);
+}
+
+.tag-explorer-wordmark {
+    display: inline-block;
+    font-family: "Parisienne", cursive;
+    font-size: clamp(2.25rem, 5vw, 3.25rem);
+    letter-spacing: .12em;
+    color: #ff7ddc;
+    text-shadow: 0 12px 45px rgba(255, 118, 214, .4);
+}
+
+.gallery-title {
+    text-transform: uppercase;
+}
+
+.top-bar-tease {
+    letter-spacing: .4em;
+    color: rgba(255, 200, 225, .75);
+}
+
+.command-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: .75rem;
+}
+
+.command-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem;
+}
+
+.command-status {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: .75rem;
+    margin-left: auto;
+    text-transform: uppercase;
+    font-size: .5rem;
+    letter-spacing: .45em;
+    color: rgba(226, 232, 240, .7);
+}
+
+.command-status span {
+    white-space: nowrap;
+}
+
+.command-btn {
+    position: relative;
+    padding: .55rem 1.35rem;
+    font-size: .6rem;
+    letter-spacing: .5em;
+    background: linear-gradient(135deg, rgba(255, 118, 214, .18), rgba(102, 243, 255, .14));
+    border-color: rgba(255, 118, 214, .45);
+    color: rgba(255, 240, 250, .92);
+    box-shadow: 0 20px 50px -28px rgba(255, 118, 214, .7);
+    text-shadow: 0 0 12px rgba(255, 118, 214, .45);
+}
+
+.command-btn::after {
+    content: "";
+    position: absolute;
+    inset: -1px;
+    border-radius: 9999px;
+    box-shadow: 0 0 25px rgba(255, 118, 214, .55);
+    opacity: 0;
+    transition: opacity .3s ease;
+    z-index: -1;
+}
+
+.command-btn:hover {
+    box-shadow: 0 25px 60px -25px rgba(255, 118, 214, .85);
+    background: linear-gradient(135deg, rgba(255, 118, 214, .28), rgba(102, 243, 255, .24));
+}
+
+.command-btn:hover::after,
+.command-btn:focus-visible::after {
+    opacity: 1;
+}
+
+.command-btn:focus-visible {
+    outline-color: #ff7ddc;
+}
+
+.command-btn--ghost {
+    background: rgba(255, 255, 255, .05);
+    border-color: rgba(255, 118, 214, .25);
+    color: rgba(236, 230, 255, .85);
+    box-shadow: none;
+}
+
+.command-btn--ghost:hover {
+    background: rgba(255, 118, 214, .16);
+    color: rgba(255, 250, 255, .95);
+}
+
+@media (max-width: 768px) {
+    .command-bar {
+        flex-direction: column;
+        align-items: stretch;
+        gap: .9rem;
+    }
+
+    .command-status {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .top-bar-tease {
+        text-align: left;
     }
 }


### PR DESCRIPTION
## Summary
- rewrite the Tailwind rework proposal to cover the sticky command ribbon, 100 artist pagination, and fullscreen hardening
- restyle the landing header with a feminine TagExplorer wordmark and a pinned PINNED/AUDIO/GLOW/PROMPT/FILTER command bar that sticks with a glow state on scroll
- harden gallery pagination and sorting by loading artists in 100-item pages, preventing duplicate renders, and adding a sticky-top-bar helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce6c244eac832c8f37ec108a1f947b