### PR TITLE
Define pagination state for debug interface

### DIFF
--- a/modules/gallery.js
+++ b/modules/gallery.js
@@ -30,6 +30,11 @@ let artistsPerPage = DEFAULT_ARTISTS_PER_PAGE;
 let currentPage = 1;
 let totalPages = 0;
 const renderedPages = new Set();
+const pagination = {
+  current: 1,
+  perPage: DEFAULT_ARTISTS_PER_PAGE,
+  total: 0,
+};
 
 const resolvePerPage = (value) => {
   const floored = Math.floor(Number(value));


### PR DESCRIPTION
## Summary
- define the gallery pagination state object so the debug interface can safely expose it on `window`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d23acdf7cc832ca8db07749f467524