### PR TITLE
Add intensity-aware whisper dispatcher and UI control

### DIFF
--- a/data/tts_lines.json
+++ b/data/tts_lines.json
@@ -1,0 +1,92 @@
+{
+  "tag_add": [
+    [],
+    [
+      "One more tag? Whisper it slow like it's a secret you'll regret.",
+      "You really need that tag? Soft hands, shaky alibi."
+    ],
+    [
+      "Stacking specifics again? You're building your own confession.",
+      "Every fresh filter is another red flag waving over you."
+    ],
+    [
+      "Another filthy tag. You're drafting the blackmail note yourself.",
+      "Keep piling them on. I'll recite the list when they ask what broke you."
+    ]
+  ],
+  "tag_clear": [
+    [],
+    [
+      "Clearing tags like that fixes anything? Cute.",
+      "Clean slate? You're only scrubbing surface shame."
+    ],
+    [
+      "Wiping the board won't erase the cravings, pet.",
+      "Delete the tags, not the urge? Transparent."
+    ],
+    [
+      "Scrub all you want. The site remembers how filthy you were.",
+      "Reset complete. Your guilt remains."
+    ]
+  ],
+  "stack_overflow": [
+    [],
+    [
+      "Five tags already? Slow down, rabbit.",
+      "That's a lot of filters for someone claiming they're just browsing."
+    ],
+    [
+      "You're choking the feed with kinks. Desperation looks good on you.",
+      "Stacking tags past five? You're begging to be profiled."
+    ],
+    [
+      "Six, seven, eight... you're compiling evidence against yourself.",
+      "That filter stack screams 'obsession'. Wear it."
+    ]
+  ],
+  "artist_open": [
+    [],
+    [
+      "Zooming in already? Couldn't wait, could you?",
+      "That artist again? Quietly obsessed."
+    ],
+    [
+      "Of course you opened them. This is the part you rehearse.",
+      "Caught you ogling your favorite mess. Again."
+    ],
+    [
+      "That's the face you wanted. Stay. Stare. Own the need.",
+      "Full screen? You're not exploring—you're surrendering."
+    ]
+  ],
+  "idle": [
+    [],
+    [
+      "Still here? Let the guilt settle in.",
+      "Quiet? I can hear you breathing through the shame."
+    ],
+    [
+      "Went silent. Thinking about closing the tab? You won't.",
+      "No motion, just marinating in your own heat."
+    ],
+    [
+      "Idle and exposed. Even your stillness is needy.",
+      "Frozen there, letting my whispers sink under your skin."
+    ]
+  ],
+  "back": [
+    [],
+    [
+      "Running back already? Predictable.",
+      "You never leave for long."
+    ],
+    [
+      "Back to the gallery? You're addicted to the glow.",
+      "Retreat failed. Welcome home, pet."
+    ],
+    [
+      "Tried to escape. Came crawling back. I knew you would.",
+      "Door swings shut behind you. You're staying."
+    ]
+  ]
+}

--- a/modules/api.js
+++ b/modules/api.js
@@ -18,6 +18,7 @@ const ARTISTS_DATA_URL = new URL("../artists.json", import.meta.url).href;
 const TOOLTIP_DATA_URL = new URL("../tag-tooltips.json", import.meta.url).href;
 const TAUNTS_DATA_URL = new URL("../taunts.json", import.meta.url).href;
 const TAG_TAUNTS_DATA_URL = new URL("../tag-taunts.json", import.meta.url).href;
+const TTS_LINES_DATA_URL = new URL("../data/tts_lines.json", import.meta.url).href;
 
 const GALLERY_STATE_KEY = "tagexplorer:gallery:state";
 const ARTIST_LOOKUP = new Map();
@@ -694,12 +695,13 @@ function clearArtistCache(artistName) {
  */
 async function loadAppData() {
   try {
-    const [artists, tooltips, generalTaunts, tagTaunts] =
+    const [artists, tooltips, generalTaunts, tagTaunts, ttsLines] =
       await Promise.all([
         getArtistsIndex(),
         fetchWithCache(TOOLTIP_DATA_URL),
         fetchWithCache(TAUNTS_DATA_URL),
         fetchWithCache(TAG_TAUNTS_DATA_URL),
+        fetchWithCache(TTS_LINES_DATA_URL),
       ]);
 
     return {
@@ -707,6 +709,7 @@ async function loadAppData() {
       tooltips,
       generalTaunts,
       tagTaunts,
+      ttsLines,
     };
   } catch (error) {
     console.error("Failed to load required data files:", error);
@@ -750,6 +753,8 @@ export async function preloadDataset(key) {
       return fetchWithCache(TAUNTS_DATA_URL);
     case 'tag-taunts':
       return fetchWithCache(TAG_TAUNTS_DATA_URL);
+    case 'tts-lines':
+      return fetchWithCache(TTS_LINES_DATA_URL);
     default:
       return null;
   }

--- a/modules/azure-tts.js
+++ b/modules/azure-tts.js
@@ -3,6 +3,14 @@ const DEFAULT_VOICE = "en-US-AvaMultilingualNeural";
 const WHISPER_STYLE_CANONICAL = "whispering";
 const SAMPLE_PREVIEW_LINE = "Caught you tweaking my whispers again, pet.";
 
+const INTENSITY_PROFILES = {
+  1: { rate: "-15%", volume: "-32%", pitch: "-6%" },
+  2: { rate: "-10%", volume: "-24%", pitch: "-2%" },
+  3: { rate: "-6%", volume: "-16%", pitch: "+1%" },
+};
+
+const FALLBACK_INTENSITY = 2;
+
 let azureConfig = {
   voice: DEFAULT_VOICE,
   style: WHISPER_STYLE_CANONICAL,
@@ -10,6 +18,8 @@ let azureConfig = {
 
 let voiceListPromise = null;
 let latestObjectUrl = null;
+let whisperVoicePool = [];
+let whisperVoiceCursor = 0;
 let voiceSelectorOverlay = null;
 let voiceSelectorList = null;
 let styleSelectEl = null;
@@ -54,6 +64,71 @@ function applyConfigToWindow() {
   if (typeof window === "undefined") return;
   window._azureTTSVoice = azureConfig.voice;
   window._azureTTSStyle = azureConfig.style;
+}
+
+function clampIntensity(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return FALLBACK_INTENSITY;
+  if (numeric <= 0) return 0;
+  if (numeric >= 3) return 3;
+  return Math.max(1, Math.floor(numeric));
+}
+
+function getIntensityProfile(intensity) {
+  const lane = clampIntensity(intensity) || FALLBACK_INTENSITY;
+  return INTENSITY_PROFILES[lane] || INTENSITY_PROFILES[FALLBACK_INTENSITY];
+}
+
+function normalizeVoicePoolEntry(voice) {
+  if (!voice || typeof voice !== "object") return null;
+  const styles = filterWhisperStyles(voice.StyleList);
+  if (!styles.length) return null;
+  return {
+    voice: voice.ShortName || voice.VoiceId || DEFAULT_VOICE,
+    styles,
+  };
+}
+
+function registerWhisperVoicePool(voices = []) {
+  const normalized = Array.isArray(voices)
+    ? voices
+        .map(normalizeVoicePoolEntry)
+        .filter(Boolean)
+    : [];
+  if (!normalized.length) return;
+  whisperVoicePool = normalized;
+  whisperVoiceCursor = 0;
+}
+
+function pickStyleForIntensity(styles = [], intensity = FALLBACK_INTENSITY) {
+  if (!Array.isArray(styles) || styles.length === 0) {
+    return azureConfig.style || WHISPER_STYLE_CANONICAL;
+  }
+  const canonical = styles.find(
+    (style) => canonicalizeStyle(style) === WHISPER_STYLE_CANONICAL
+  );
+  if (canonical) return canonical;
+  const containsWhisper = styles.find((style) =>
+    String(style).toLowerCase().includes("whisper")
+  );
+  if (containsWhisper) return containsWhisper;
+  const index = clampIntensity(intensity) % styles.length;
+  return styles[index];
+}
+
+function getNextWhisperConfig(intensity = FALLBACK_INTENSITY) {
+  if (!whisperVoicePool.length) {
+    return {
+      voice: azureConfig.voice || DEFAULT_VOICE,
+      style: azureConfig.style || WHISPER_STYLE_CANONICAL,
+    };
+  }
+  const entry = whisperVoicePool[whisperVoiceCursor % whisperVoicePool.length];
+  whisperVoiceCursor = (whisperVoiceCursor + 1) % whisperVoicePool.length;
+  return {
+    voice: entry.voice,
+    style: pickStyleForIntensity(entry.styles, intensity),
+  };
 }
 
 function emitConfigChange() {
@@ -156,12 +231,17 @@ async function fetchAzureVoices(key, region, { forceRefresh = false } = {}) {
   return Array.isArray(voices) ? voices : [];
 }
 
-function buildSSML(text, config) {
+function buildSSML(text, config, { intensity, event } = {}) {
   const { voice, style } = normalizeVoiceConfig(config);
+  const profile = getIntensityProfile(intensity ?? FALLBACK_INTENSITY);
   const safeText = text.replace(/[<>]/g, "");
+  const prosodyOpen = `<prosody rate="${profile.rate}" volume="${profile.volume}" pitch="${profile.pitch}">`;
+  const prosodyClose = `</prosody>`;
+  const eventAttr = event ? ` mstts:styledegree="1.0"` : "";
+  const inner = `${prosodyOpen}${safeText}${prosodyClose}`;
   const content = style
-    ? `<mstts:express-as style="${style}">${safeText}</mstts:express-as>`
-    : safeText;
+    ? `<mstts:express-as style="${style}"${eventAttr}>${inner}</mstts:express-as>`
+    : inner;
   return `<?xml version="1.0" encoding="utf-8"?>
 <speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" xml:lang="en-US" xmlns:mstts="https://www.w3.org/2001/mstts">
   <voice name="${voice}">
@@ -170,14 +250,26 @@ function buildSSML(text, config) {
 </speak>`;
 }
 
-async function azureSpeak(text, overrides = {}) {
+async function azureSpeak(text, overrides = {}, meta = {}) {
   if (!text) return null;
   const { key, region } = await ensureCredentials();
-  // When no overrides provided, use the current stored configuration
-  const config = Object.keys(overrides).length === 0 
-    ? { ...azureConfig }  // Use current config directly
-    : normalizeVoiceConfig(overrides);  // Merge with overrides
-  const ssml = buildSSML(text, config);
+  const {
+    ssml: ssmlOverride,
+    intensity: overrideIntensity,
+    ...voiceOverrides
+  } = overrides || {};
+  const hasOverrides = Object.keys(voiceOverrides).length > 0;
+  const config = hasOverrides
+    ? normalizeVoiceConfig(voiceOverrides)
+    : { ...azureConfig };
+  const resolvedIntensity =
+    clampIntensity(
+      overrideIntensity ?? meta.intensity ?? FALLBACK_INTENSITY
+    ) || FALLBACK_INTENSITY;
+  const ssml = ssmlOverride || buildSSML(text, config, {
+    intensity: resolvedIntensity,
+    event: meta.event,
+  });
 
   const response = await fetch(synthesisEndpoint(region), {
     method: "POST",
@@ -201,6 +293,20 @@ async function azureSpeak(text, overrides = {}) {
   }
   latestObjectUrl = URL.createObjectURL(blob);
   return latestObjectUrl;
+}
+
+function composeWhisperSSML(text, { intensity, event, voice, style, rotate = false } = {}) {
+  const lane = clampIntensity(intensity ?? FALLBACK_INTENSITY) || FALLBACK_INTENSITY;
+  let config;
+  if (rotate) {
+    config = getNextWhisperConfig(lane);
+  } else if (voice || style) {
+    config = normalizeVoiceConfig({ voice, style });
+  } else {
+    config = { ...azureConfig };
+  }
+  const ssml = buildSSML(text, config, { intensity: lane, event });
+  return { ssml, voice: config.voice, style: config.style, intensity: lane };
 }
 
 function highlightSelectedVoice(shortName) {
@@ -475,6 +581,7 @@ async function showAzureVoiceSelector() {
   }
 
   if (whisperVoices.length > 0) {
+    registerWhisperVoicePool(whisperVoices);
     renderVoiceOptions(whisperVoices);
     const activeVoice = whisperVoices.find(
       (voice) => voice.ShortName === azureConfig.voice
@@ -532,6 +639,9 @@ export {
   showAzureVoiceSelector,
   DEFAULT_VOICE,
   WHISPER_STYLE_CANONICAL,
+  composeWhisperSSML,
+  getNextWhisperConfig,
+  registerWhisperVoicePool,
 };
 
 export async function ensureDefaultWhisperVoice() {
@@ -551,6 +661,7 @@ export async function ensureDefaultWhisperVoice() {
             )
           : [];
         if (whisperVoices.length) {
+          registerWhisperVoicePool(whisperVoices);
           const currentVoice = window._azureTTSVoice;
           const preferred = whisperVoices.find((voice) => voice.ShortName === currentVoice);
           const fallback =

--- a/modules/gallery.js
+++ b/modules/gallery.js
@@ -13,6 +13,7 @@ import { pickThumbnailCandidateUrls } from "./thumbnail-chooser.js";
 import { enhanceGalleryImages, injectImageQualityCss } from "./image-quality.js";
 import { showSimilarArtistsModal, setAllArtists as setSimilarArtists } from "./similar-artists.js";
 import { toggleFavorite, isFavorite } from "./favorites.js";
+import { dispatchWhisperEvent } from "./tts-dispatcher.js";
 
 /**
  * Returns the thumbnail URL for an artist (used by sidebar and cards)
@@ -479,6 +480,7 @@ function primeVisibleArtistImages(buffer = 180) {
 async function openArtistZoom(artist) {
   // remove existing viewer
   document.querySelectorAll(".fullscreen-wrapper").forEach((el) => el.remove());
+  dispatchWhisperEvent('artist_open', { minIntensity: 2 });
 
   let grid, zoomContent, backBtn;
   let posts = [];

--- a/modules/pages/gallery.js
+++ b/modules/pages/gallery.js
@@ -45,16 +45,18 @@ import {
   restoreGalleryState,
 } from '../api.js';
 import { startTauntTicker } from '../humiliation.js';
-import { createTTSToggleButton } from '../tts-toggle.js';
+import { createTTSToggleButton, createTTSIntensityControl } from '../tts-toggle.js';
 import {
   initTagExplorer,
   openTagExplorer,
   setAllArtists as setExplorerArtists,
 } from '../tag-explorer.js';
 import { showAzureVoiceSelector } from '../azure-tts.js';
+import { configureWhisperCatalog, dispatchWhisperEvent } from '../tts-dispatcher.js';
 
 const MOTION_STORAGE_KEY = 'te.motion.preference';
 const MOTION_DEFAULT = 'full';
+const IDLE_THRESHOLD_MS = 60000;
 
 function readMotionPreference() {
   if (typeof window === 'undefined') return MOTION_DEFAULT;
@@ -542,16 +544,61 @@ function setupForceFetch() {
   });
 }
 
+function setupIdleWhispers() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return () => {};
+  }
+  let idleTimer = null;
+
+  const schedule = () => {
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      dispatchWhisperEvent('idle', { minIntensity: 1 });
+      schedule();
+    }, IDLE_THRESHOLD_MS);
+  };
+
+  const handleActivity = () => {
+    if (document.visibilityState === 'hidden') return;
+    schedule();
+  };
+
+  const handleVisibility = () => {
+    if (document.visibilityState === 'hidden') {
+      if (idleTimer) clearTimeout(idleTimer);
+    } else {
+      schedule();
+    }
+  };
+
+  const events = ['pointerdown', 'keydown', 'mousemove', 'scroll', 'touchstart', 'focus'];
+  events.forEach((eventName) =>
+    window.addEventListener(eventName, handleActivity, { passive: true })
+  );
+  document.addEventListener('visibilitychange', handleVisibility);
+
+  schedule();
+
+  return () => {
+    if (idleTimer) clearTimeout(idleTimer);
+    events.forEach((eventName) =>
+      window.removeEventListener(eventName, handleActivity)
+    );
+    document.removeEventListener('visibilitychange', handleVisibility);
+  };
+}
+
 export async function initGalleryPage({ foldAdapter } = {}) {
   const savedState = restoreGalleryState();
 
-  const { artists, tooltips, generalTaunts, tagTaunts } = await loadAppData();
+  const { artists, tooltips, generalTaunts, tagTaunts, ttsLines } = await loadAppData();
 
   initUI();
   initSidebar();
   await initAudio();
   initAudioUI();
   createTTSToggleButton();
+  createTTSIntensityControl();
   setupVoiceSelectorButton();
   setupAudioToggle();
   setupMuteToggle();
@@ -580,6 +627,11 @@ export async function initGalleryPage({ foldAdapter } = {}) {
   setTagTooltips(tooltips);
   setTagTaunts(tagTaunts);
   setTaunts(generalTaunts);
+  configureWhisperCatalog({
+    events: ttsLines,
+    tags: tagTaunts,
+    generalTaunts,
+  });
   startTauntTicker(generalTaunts, 30000);
 
   const quotes = Object.values(tooltips || {}).filter(Boolean);
@@ -623,6 +675,8 @@ export async function initGalleryPage({ foldAdapter } = {}) {
   setupForceFetch();
   setupFavoritesButton();
 
+  const idleCleanup = setupIdleWhispers();
+
   window.kexplorer = {
     filterArtists,
     setRandomBackground,
@@ -652,6 +706,7 @@ export async function initGalleryPage({ foldAdapter } = {}) {
       if (settingsSheet && typeof settingsSheet.close === 'function') {
         settingsSheet.close();
       }
+      if (typeof idleCleanup === 'function') idleCleanup();
     },
   };
 }

--- a/modules/router.js
+++ b/modules/router.js
@@ -1,4 +1,5 @@
 import { preloadArtistBySlug, preloadDataset } from './api.js';
+import { dispatchWhisperEvent } from './tts-dispatcher.js';
 
 const ARTIST_ROUTE_REGEX = /\/artist\/([^/]+)\/?$/;
 
@@ -70,6 +71,10 @@ export function initRouter({ beforeNavigate } = {}) {
 
   window.addEventListener('pageshow', () => {
     setTimeout(clearGlitch, 120);
+  });
+
+  window.addEventListener('popstate', () => {
+    dispatchWhisperEvent('back', { maxIntensity: 2 });
   });
 }
 

--- a/modules/sidebar.js
+++ b/modules/sidebar.js
@@ -7,6 +7,7 @@ import { getThumbnailUrl } from "./gallery.js";
 import { azureSpeak } from "./azure-tts.js";
 import { getActiveTags } from "./tags.js";
 import { isTTSEnabled, createTTSToggleButton } from "./tts-toggle.js";
+import { dispatchWhisperEvent } from "./tts-dispatcher.js";
 
 if (typeof window !== "undefined") {
   window.addEventListener("DOMContentLoaded", () => {
@@ -102,6 +103,9 @@ function handleArtistCopy(artist, imgSrc) {
       showToast(
         added ? `Copied: ${artistTag}` : `Copied again: ${artistTag}`
       );
+      if (added && copiedArtists.size > 5) {
+        dispatchWhisperEvent('stack_overflow', { minIntensity: 2 });
+      }
       // --- INCREASE HUMILIATION METER ---
       if (typeof window.incrementDesperationMeter === "function") {
         window.incrementDesperationMeter(1);

--- a/modules/tags.js
+++ b/modules/tags.js
@@ -1,6 +1,8 @@
 import { vibrate } from "./ui.js";
 import { fetchWithCache } from "./fetch-cache.js";
 import { categorizeTags, flattenCategorizedTags } from "./tag-categories.js";
+import { dispatchWhisperEvent, getTagLineForIntensity } from "./tts-dispatcher.js";
+import { getTTSIntensity } from "./tts-toggle.js";
 
 /**
  * Tags module - Handles tag filtering, buttons, and related functionality
@@ -118,9 +120,13 @@ function spawnBubble(tag) {
   chibi.src = "icons/chibi.png";
   chibi.className = "chibi";
   const line = document.createElement("span");
-  const pool = tagTaunts[tag] || taunts;
+  const intensity = getTTSIntensity();
+  const candidate = getTagLineForIntensity(tag, intensity);
+  const fallbackPool = Array.isArray(taunts) ? taunts : [];
+  const fallbackLine = fallbackPool[Math.floor(Math.random() * fallbackPool.length)];
   line.textContent =
-    pool[Math.floor(Math.random() * pool.length)] ||
+    candidate ||
+    fallbackLine ||
     `Still chasing '${tag}' huh? You're beyond help.`;
   div.append(chibi, line);
   jrpgBubbles.appendChild(div);
@@ -246,9 +252,12 @@ function renderTagButtons() {
         if (activeTags.has(tag)) {
           activeTags.delete(tag);
         } else {
-          if (activeTags.size >= 2) return;
           activeTags.add(tag);
           spawnBubble(tag);
+          dispatchWhisperEvent('tag_add', { tag, maxIntensity: 2 });
+          if (activeTags.size > 5) {
+            dispatchWhisperEvent('stack_overflow', { minIntensity: 2 });
+          }
         }
         button.setAttribute(
           "aria-pressed",
@@ -278,9 +287,12 @@ function renderTagButtons() {
       if (activeTags.has(filter)) {
         activeTags.delete(filter);
       } else {
-        if (activeTags.size >= 2) return;
         activeTags.add(filter);
         spawnBubble(filter);
+        dispatchWhisperEvent('tag_add', { tag: filter, maxIntensity: 2 });
+        if (activeTags.size > 5) {
+          dispatchWhisperEvent('stack_overflow', { minIntensity: 2 });
+        }
       }
       renderTagButtons();
       if (renderArtists) renderArtists(true);
@@ -295,22 +307,28 @@ function renderTagButtons() {
  * Clears all active tags
  */
 function clearAllTags() {
+  const hadTags = activeTags.size > 0;
   activeTags.clear();
   renderTagButtons();
   if (navigator.vibrate) navigator.vibrate(50);
   if (renderArtists) renderArtists(true); // <-- force full update
   if (setRandomBackground) setRandomBackground();
   emitTagUpdate();
+  if (hadTags) {
+    dispatchWhisperEvent('tag_clear', { maxIntensity: 2 });
+  }
 }
 
 /**
  * Toggles a single tag on or off
  */
 function toggleTag(tag) {
+  let added = false;
   if (activeTags.has(tag)) {
     activeTags.delete(tag);
   } else {
     activeTags.add(tag);
+    added = true;
     spawnBubble(tag);
   }
   // After changing state, try to update any visible tag buttons' aria-pressed
@@ -323,6 +341,12 @@ function toggleTag(tag) {
   if (setRandomBackground) setRandomBackground();
   if (navigator.vibrate) navigator.vibrate(50);
   emitTagUpdate();
+  if (added) {
+    dispatchWhisperEvent('tag_add', { tag, maxIntensity: 2 });
+    if (activeTags.size > 5) {
+      dispatchWhisperEvent('stack_overflow', { minIntensity: 2 });
+    }
+  }
 }
 
 function hydrateTagState(tags, { silent = false } = {}) {

--- a/modules/tts-dispatcher.js
+++ b/modules/tts-dispatcher.js
@@ -1,0 +1,338 @@
+import {
+  azureSpeak,
+  composeWhisperSSML,
+} from './azure-tts.js';
+import {
+  isTTSEnabled,
+  getTTSIntensity,
+} from './tts-toggle.js';
+
+const LANE_MIN = 1;
+const LANE_MAX = 3;
+const CAPTION_VISIBLE_MS = 12000;
+const GLOBAL_COOLDOWN_MS = 2800;
+const DEFAULT_EVENT_COOLDOWN_MS = 3600;
+const EVENT_COOLDOWNS = {
+  idle: 90000,
+  back: 8000,
+  artist_open: 5200,
+  stack_overflow: 6200,
+  tag_add: 2600,
+  tag_clear: 4200,
+};
+
+let eventCatalog = {};
+let tagCatalog = {};
+let generalFallback = [];
+
+let captionRoot = null;
+let captionTextEl = null;
+let captionTimer = null;
+let audioEl = null;
+
+let lastTriggerTimes = new Map();
+let globalCooldownUntil = 0;
+let scrollSuppressedUntil = 0;
+let lastScrollY = null;
+let lastScrollEvent = 0;
+
+function clampLane(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return LANE_MIN;
+  if (numeric <= 0) return 0;
+  if (numeric >= LANE_MAX) return LANE_MAX;
+  return Math.max(LANE_MIN, Math.floor(numeric));
+}
+
+function normalizeArrayLane(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+    .filter(Boolean);
+}
+
+function normalizeIntensityMatrix(raw) {
+  const matrix = [[], [], [], []];
+  if (Array.isArray(raw)) {
+    raw.forEach((lane, index) => {
+      if (index >= 0 && index < matrix.length) {
+        matrix[index] = normalizeArrayLane(lane);
+      }
+    });
+    return matrix;
+  }
+  if (raw && typeof raw === 'object') {
+    Object.keys(raw).forEach((key) => {
+      const index = Number(key);
+      if (Number.isInteger(index) && index >= 0 && index < matrix.length) {
+        matrix[index] = normalizeArrayLane(raw[key]);
+      }
+    });
+  }
+  return matrix;
+}
+
+function ensureCaptionRoot() {
+  if (typeof document === 'undefined') return null;
+  if (captionRoot && captionTextEl && document.body.contains(captionRoot)) {
+    return captionRoot;
+  }
+  captionRoot = document.createElement('div');
+  captionRoot.id = 'whisper-caption';
+  captionRoot.className = 'whisper-caption whisper-caption--hidden';
+  captionRoot.setAttribute('aria-live', 'assertive');
+  captionRoot.setAttribute('role', 'status');
+  captionTextEl = document.createElement('span');
+  captionTextEl.className = 'whisper-caption__text';
+  captionRoot.appendChild(captionTextEl);
+  document.body.appendChild(captionRoot);
+  return captionRoot;
+}
+
+function ensureAudioElement() {
+  if (typeof window === 'undefined') return null;
+  if (audioEl && document.body.contains(audioEl)) return audioEl;
+  audioEl = document.getElementById('whisper-audio-element');
+  if (!audioEl) {
+    audioEl = document.createElement('audio');
+    audioEl.id = 'whisper-audio-element';
+    audioEl.setAttribute('aria-hidden', 'true');
+    audioEl.setAttribute('preload', 'auto');
+    audioEl.className = 'whisper-audio-element hidden';
+    document.body.appendChild(audioEl);
+  }
+  audioEl.volume = 1;
+  return audioEl;
+}
+
+function hideCaptionSoon() {
+  if (!captionRoot) return;
+  if (captionTimer) clearTimeout(captionTimer);
+  captionTimer = setTimeout(() => {
+    if (captionRoot) {
+      captionRoot.classList.add('whisper-caption--hidden');
+      captionRoot.classList.remove('whisper-caption--muted');
+    }
+  }, CAPTION_VISIBLE_MS);
+}
+
+function updateCaption(text, { muted = false } = {}) {
+  if (!text) {
+    if (captionRoot) {
+      captionRoot.classList.add('whisper-caption--hidden');
+      captionRoot.classList.remove('whisper-caption--muted');
+    }
+    return;
+  }
+  ensureCaptionRoot();
+  if (!captionRoot || !captionTextEl) return;
+  captionTextEl.textContent = text;
+  captionRoot.classList.remove('whisper-caption--hidden');
+  captionRoot.classList.toggle('whisper-caption--muted', Boolean(muted));
+  hideCaptionSoon();
+}
+
+function pickFromMatrix(matrix, lane) {
+  if (!Array.isArray(matrix) || !matrix.length) return null;
+  const targetIndex = Math.min(Math.max(lane, 0), matrix.length - 1);
+  const primary = normalizeArrayLane(matrix[targetIndex]);
+  if (primary.length) {
+    return primary[Math.floor(Math.random() * primary.length)];
+  }
+  for (let i = targetIndex - 1; i >= 0; i -= 1) {
+    const bucket = normalizeArrayLane(matrix[i]);
+    if (bucket.length) {
+      return bucket[Math.floor(Math.random() * bucket.length)];
+    }
+  }
+  for (let i = targetIndex + 1; i < matrix.length; i += 1) {
+    const bucket = normalizeArrayLane(matrix[i]);
+    if (bucket.length) {
+      return bucket[Math.floor(Math.random() * bucket.length)];
+    }
+  }
+  return null;
+}
+
+function resolveLane(userLane, { intensity, minIntensity, maxIntensity } = {}) {
+  const userCap = clampLane(userLane);
+  if (userCap === 0) return 0;
+  if (typeof intensity === 'number') {
+    const forced = clampLane(intensity);
+    if (forced === 0) return 0;
+    return Math.min(userCap, forced);
+  }
+  const minLane = typeof minIntensity === 'number' ? clampLane(minIntensity) : LANE_MIN;
+  const maxLane = typeof maxIntensity === 'number' ? clampLane(maxIntensity) : LANE_MAX;
+  const allowedMax = Math.min(userCap, maxLane || LANE_MAX);
+  if (allowedMax === 0) return 0;
+  if (userCap < minLane) {
+    return userCap;
+  }
+  return Math.max(minLane || LANE_MIN, allowedMax || userCap);
+}
+
+function getEventCooldown(eventKey) {
+  const normalized = String(eventKey || '').toLowerCase();
+  return EVENT_COOLDOWNS[normalized] ?? DEFAULT_EVENT_COOLDOWN_MS;
+}
+
+function configureWhisperCatalog({ events, tags, generalTaunts } = {}) {
+  const nextEvents = {};
+  if (events && typeof events === 'object') {
+    Object.entries(events).forEach(([key, value]) => {
+      nextEvents[String(key || '').toLowerCase()] = normalizeIntensityMatrix(value);
+    });
+  }
+  eventCatalog = nextEvents;
+  const nextTags = {};
+  if (tags && typeof tags === 'object') {
+    Object.entries(tags).forEach(([key, value]) => {
+      nextTags[String(key || '').toLowerCase()] = normalizeIntensityMatrix(value);
+    });
+  }
+  tagCatalog = nextTags;
+  generalFallback = Array.isArray(generalTaunts)
+    ? generalTaunts.filter((line) => typeof line === 'string' && line.trim().length > 0)
+    : [];
+}
+
+function getTagLineForIntensity(tag, lane, fallback) {
+  const key = String(tag || '').toLowerCase();
+  const matrix = tagCatalog[key];
+  if (!matrix) {
+    return fallback || null;
+  }
+  const resolvedLane = clampLane(lane || LANE_MIN);
+  const line = pickFromMatrix(matrix, resolvedLane);
+  if (line) return line;
+  return fallback || null;
+}
+
+async function playLineThroughAzure(text, eventKey, lane) {
+  try {
+    const { ssml, voice, style, intensity } = composeWhisperSSML(text, {
+      intensity: lane,
+      event: eventKey,
+      rotate: true,
+    });
+    const url = await azureSpeak(text, { ssml, voice, style, intensity }, {
+      event: eventKey,
+      intensity: lane,
+    });
+    if (!url) return false;
+    const audio = ensureAudioElement();
+    if (!audio) return false;
+    if (!audio.paused) {
+      try {
+        audio.pause();
+      } catch (error) {
+        // ignore pause errors
+      }
+    }
+    audio.currentTime = 0;
+    audio.src = url;
+    audio.play().catch(() => {});
+    return true;
+  } catch (error) {
+    console.warn('[tts-dispatcher] Failed to play whisper', error);
+    return false;
+  }
+}
+
+function shouldSuppressForScroll(now) {
+  if (!scrollSuppressedUntil) return false;
+  return now < scrollSuppressedUntil;
+}
+
+function recordScrollSuppression() {
+  if (typeof window === 'undefined') return;
+  const now = Date.now();
+  const currentY = window.scrollY || window.pageYOffset || 0;
+  if (lastScrollY !== null) {
+    const delta = Math.abs(currentY - lastScrollY);
+    const deltaTime = now - lastScrollEvent;
+    if (delta > 280 && deltaTime < 180) {
+      scrollSuppressedUntil = now + 1400;
+    }
+  }
+  lastScrollY = currentY;
+  lastScrollEvent = now;
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('scroll', () => recordScrollSuppression(), {
+    passive: true,
+  });
+}
+
+function dispatchWhisperEvent(eventKey, options = {}) {
+  const key = String(eventKey || '').toLowerCase();
+  if (!key) return { skipped: true, reason: 'no-event' };
+  const now = Date.now();
+
+  if (!options.forceGlobal && globalCooldownUntil && now < globalCooldownUntil) {
+    return { skipped: true, reason: 'global-cooldown' };
+  }
+
+  if (!options.ignoreScrollSuppression && shouldSuppressForScroll(now)) {
+    return { skipped: true, reason: 'rapid-scroll' };
+  }
+
+  const cooldown = options.cooldownMs ?? getEventCooldown(key);
+  const lastTriggered = lastTriggerTimes.get(key) || 0;
+  if (!options.force && cooldown && now - lastTriggered < cooldown) {
+    return { skipped: true, reason: 'event-cooldown' };
+  }
+
+  const userLane = getTTSIntensity();
+  const lane = resolveLane(userLane, options);
+  if (lane === 0) {
+    updateCaption('Whispers muted', { muted: true });
+    return { skipped: true, reason: 'intensity-zero' };
+  }
+
+  let line = options.text;
+  if (!line && options.tag) {
+    line = getTagLineForIntensity(options.tag, lane);
+  }
+  if (!line) {
+    const matrix = eventCatalog[key];
+    if (matrix) {
+      line = pickFromMatrix(matrix, lane);
+    }
+  }
+  if (!line && generalFallback.length) {
+    line = generalFallback[Math.floor(Math.random() * generalFallback.length)];
+  }
+  if (!line) {
+    return { skipped: true, reason: 'no-line' };
+  }
+
+  const enabled = isTTSEnabled();
+  updateCaption(line, { muted: !enabled });
+  lastTriggerTimes.set(key, now);
+  globalCooldownUntil = now + GLOBAL_COOLDOWN_MS;
+
+  if (!enabled) {
+    return { skipped: true, text: line, reason: 'tts-disabled' };
+  }
+
+  playLineThroughAzure(line, key, lane);
+  return { text: line, intensity: lane };
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('tts:toggle', (event) => {
+    const enabled = Boolean(event?.detail?.enabled);
+    if (!enabled) {
+      updateCaption('Whispers muted', { muted: true });
+    }
+  });
+}
+
+export {
+  configureWhisperCatalog,
+  dispatchWhisperEvent,
+  getTagLineForIntensity,
+};

--- a/modules/tts-toggle.js
+++ b/modules/tts-toggle.js
@@ -1,6 +1,24 @@
 // Simple TTS toggle state and UI
 const STORAGE_KEY = "ttsEnabled";
+const INTENSITY_STORAGE_KEY = "ttsIntensity";
+const DEFAULT_INTENSITY = 2;
+const INTENSITY_LABELS = [
+  "Muted",
+  "Hushed",
+  "Teasing",
+  "Severe",
+];
+
+function describeIntensity(level) {
+  const index = Number.isFinite(Number(level)) ? Math.max(0, Math.min(INTENSITY_LABELS.length - 1, Math.floor(Number(level)))) : 0;
+  return INTENSITY_LABELS[index] || INTENSITY_LABELS[0];
+}
+
 let ttsEnabled = true;
+let ttsIntensity = DEFAULT_INTENSITY;
+let lastNonZeroIntensity = DEFAULT_INTENSITY;
+let suppressToggleSync = false;
+let suppressIntensitySync = false;
 
 function getStorage() {
   if (typeof window !== "undefined" && window.localStorage) {
@@ -22,6 +40,16 @@ function persistTTSEnabled() {
   }
 }
 
+function persistTTSIntensity() {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(INTENSITY_STORAGE_KEY, String(ttsIntensity));
+  } catch (error) {
+    // Ignore storage errors
+  }
+}
+
 function dispatchToggleEvent(didChange) {
   if (
     typeof document === "undefined" ||
@@ -35,13 +63,37 @@ function dispatchToggleEvent(didChange) {
   );
 }
 
+function dispatchIntensityEvent(didChange) {
+  if (
+    typeof document === "undefined" ||
+    typeof CustomEvent !== "function" ||
+    !didChange
+  ) {
+    return;
+  }
+  document.dispatchEvent(
+    new CustomEvent("tts:intensity", { detail: { intensity: ttsIntensity } })
+  );
+}
+
 function applyTTSEnabledState(options = {}) {
   const { didChange = false } = options;
   if (typeof window !== "undefined") {
     window._ttsEnabled = ttsEnabled;
   }
   updateTTSToggleButton();
+  updateIntensityControl();
   dispatchToggleEvent(didChange);
+}
+
+function applyIntensityState(options = {}) {
+  const { didChange = false } = options;
+  if (typeof window !== "undefined") {
+    window._ttsIntensity = ttsIntensity;
+  }
+  updateTTSToggleButton();
+  updateIntensityControl();
+  dispatchIntensityEvent(didChange);
 }
 
 function isTTSEnabled() {
@@ -54,24 +106,86 @@ function setTTSEnabled(enabled) {
   ttsEnabled = normalized;
   persistTTSEnabled();
   applyTTSEnabledState({ didChange });
+  if (!suppressIntensitySync) {
+    if (ttsEnabled && ttsIntensity === 0) {
+      const fallback = lastNonZeroIntensity > 0 ? lastNonZeroIntensity : DEFAULT_INTENSITY;
+      suppressToggleSync = true;
+      suppressIntensitySync = true;
+      setTTSIntensity(fallback);
+      suppressIntensitySync = false;
+      suppressToggleSync = false;
+    } else if (!ttsEnabled && ttsIntensity > 0) {
+      lastNonZeroIntensity = ttsIntensity;
+    }
+  }
   return ttsEnabled;
 }
 
-function loadTTSEnabled() {
+function getTTSIntensity() {
+  return ttsIntensity;
+}
+
+function setTTSIntensity(value) {
+  const numeric = Number(value);
+  const clamped = Number.isFinite(numeric)
+    ? Math.max(0, Math.min(3, Math.floor(numeric)))
+    : DEFAULT_INTENSITY;
+  const didChange = clamped !== ttsIntensity;
+  if (!didChange) return ttsIntensity;
+  ttsIntensity = clamped;
+  if (clamped > 0) {
+    lastNonZeroIntensity = clamped;
+  }
+  persistTTSIntensity();
+  applyIntensityState({ didChange });
+
+  if (!suppressToggleSync) {
+    if (clamped === 0 && ttsEnabled) {
+      suppressIntensitySync = true;
+      setTTSEnabled(false);
+      suppressIntensitySync = false;
+    } else if (clamped > 0 && !ttsEnabled) {
+      suppressIntensitySync = true;
+      setTTSEnabled(true);
+      suppressIntensitySync = false;
+    }
+  }
+
+  return ttsIntensity;
+}
+
+function loadTTSPreferences() {
   const storage = getStorage();
   if (storage) {
     try {
-      const saved = storage.getItem(STORAGE_KEY);
-      if (saved === "0") {
+      const savedEnabled = storage.getItem(STORAGE_KEY);
+      if (savedEnabled === "0") {
         ttsEnabled = false;
-      } else if (saved === "1") {
+      } else if (savedEnabled === "1") {
         ttsEnabled = true;
+      }
+      const savedIntensity = storage.getItem(INTENSITY_STORAGE_KEY);
+      if (savedIntensity !== null && savedIntensity !== undefined) {
+        const numeric = Number(savedIntensity);
+        if (Number.isFinite(numeric)) {
+          const clamped = Math.max(0, Math.min(3, Math.floor(numeric)));
+          ttsIntensity = clamped;
+          if (clamped > 0) {
+            lastNonZeroIntensity = clamped;
+          }
+        }
       }
     } catch (error) {
       // Ignore storage access issues
     }
   }
+  if (ttsIntensity === 0 && ttsEnabled) {
+    suppressToggleSync = true;
+    setTTSEnabled(false);
+    suppressToggleSync = false;
+  }
   applyTTSEnabledState({ didChange: false });
+  applyIntensityState({ didChange: false });
 }
 
 function createTTSToggleButton() {
@@ -93,20 +207,80 @@ function createTTSToggleButton() {
   updateTTSToggleButton();
 }
 
+function createTTSIntensityControl() {
+  if (typeof document === "undefined") return;
+  const controls = document.querySelector(".audio-controls");
+  if (!controls) return;
+
+  let btn = document.getElementById("tts-intensity-btn");
+  if (!btn) {
+    btn = document.createElement("button");
+    btn.type = "button";
+    btn.id = "tts-intensity-btn";
+    btn.className = "audio-pill tts-intensity-btn";
+    btn.addEventListener("click", () => {
+      const current = getTTSIntensity();
+      const next = (current + 1) % 4;
+      setTTSIntensity(next);
+    });
+    btn.addEventListener("keydown", (event) => {
+      if (event.key === "ArrowRight" || event.key === "ArrowUp") {
+        event.preventDefault();
+        const next = Math.min(3, getTTSIntensity() + 1);
+        setTTSIntensity(next);
+      } else if (event.key === "ArrowLeft" || event.key === "ArrowDown") {
+        event.preventDefault();
+        const next = Math.max(0, getTTSIntensity() - 1);
+        setTTSIntensity(next);
+      }
+    });
+    controls.appendChild(btn);
+  }
+  updateIntensityControl();
+}
+
+function updateIntensityControl() {
+  if (typeof document === "undefined") return;
+  const btn = document.getElementById("tts-intensity-btn");
+  if (!btn) return;
+  const enabled = isTTSEnabled();
+  const intensity = getTTSIntensity();
+  const readable = describeIntensity(intensity);
+  const label = intensity === 0 ? "Muted" : readable;
+  btn.textContent = `🎚 ${label}`;
+  const ariaSuffix = !enabled ? " (muted)" : "";
+  btn.setAttribute("aria-label", `Whisper intensity ${label}${ariaSuffix}`);
+  btn.setAttribute("data-intensity", String(intensity));
+  btn.setAttribute("title", `Whisper intensity: ${label}`);
+  btn.classList.toggle("is-muted", !enabled || intensity === 0);
+}
+
 function updateTTSToggleButton() {
   if (typeof document === "undefined") return;
   const btn = document.getElementById("tts-toggle-btn");
   if (!btn) return;
 
   const enabled = isTTSEnabled();
-  const label = enabled ? "Disable whispered taunts" : "Enable whispered taunts";
-  btn.textContent = enabled ? "🔊 Whisper On" : "🔇 Whisper Off";
+  const intensity = getTTSIntensity();
+  const readable = describeIntensity(enabled ? intensity : 0);
+  const label = enabled
+    ? `Disable whispered taunts (current intensity ${readable})`
+    : "Enable whispered taunts";
+  const text = enabled && intensity > 0 ? `🔊 Whisper ${readable}` : "🔇 Whisper Off";
+  btn.textContent = text;
   btn.setAttribute("aria-pressed", enabled ? "true" : "false");
   btn.setAttribute("aria-label", label);
   btn.setAttribute("title", label);
 }
 
 // On load
-loadTTSEnabled();
+loadTTSPreferences();
 
-export { isTTSEnabled, setTTSEnabled, createTTSToggleButton };
+export {
+  isTTSEnabled,
+  setTTSEnabled,
+  createTTSToggleButton,
+  createTTSIntensityControl,
+  getTTSIntensity,
+  setTTSIntensity,
+};

--- a/style.css
+++ b/style.css
@@ -857,3 +857,51 @@
   color: rgba(255, 179, 211, 0.75);
   letter-spacing: 0.2em;
 }
+
+/* Whisper caption overlay */
+.whisper-caption {
+  position: fixed;
+  bottom: clamp(1.5rem, 6vw, 3rem);
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(15, 12, 28, 0.88);
+  color: rgba(245, 240, 255, 0.92);
+  padding: 0.75rem 1.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(128, 76, 255, 0.45);
+  box-shadow: 0 18px 46px rgba(8, 6, 20, 0.55);
+  font-size: 0.82rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  z-index: 2400;
+  backdrop-filter: blur(18px);
+  max-width: min(90vw, 520px);
+  text-align: center;
+  transition: opacity 0.35s ease, transform 0.35s ease;
+  opacity: 1;
+  pointer-events: none;
+}
+
+.whisper-caption__text {
+  display: inline-block;
+}
+
+.whisper-caption--hidden {
+  opacity: 0;
+  transform: translate(-50%, 14px);
+}
+
+.whisper-caption--muted {
+  border-color: rgba(255, 132, 132, 0.45);
+  color: rgba(255, 198, 198, 0.88);
+}
+
+.audio-controls .tts-intensity-btn {
+  min-width: 132px;
+  letter-spacing: 0.14em;
+}
+
+.tts-intensity-btn.is-muted {
+  opacity: 0.55;
+  filter: saturate(0.6);
+}

--- a/tag-taunts.json
+++ b/tag-taunts.json
@@ -1,62 +1,74 @@
 {
   "chastity_cage": [
-    "Still locked up? Good. That cage is your home now.",
-    "You weren\u2019t going to use that thing anyway.",
-    "Denied again. That\u2019s your new normal."
+    [],
+    ["Still locked up? Good. That cage is your home now."],
+    ["You weren't going to use that thing anyway."],
+    ["Denied again. That's your new normal."]
   ],
   "futanari": [
-    "Dreaming of cock again? You\u2019re practically begging for it.",
-    "She\u2019s got what you wish you had.",
-    "So eager for something bigger, huh?"
+    [],
+    ["Dreaming of cock again? You're practically begging for it."],
+    ["She's got what you wish you had."],
+    ["So eager for something bigger, huh?"]
   ],
   "orgasm_denial": [
-    "Denied. Again. And again. It\u2019s all you deserve.",
-    "Edge harder, loser. That\u2019s all you get.",
-    "No release. Only frustration and obedience."
+    [],
+    ["Denied. Again. And again. It's all you deserve."],
+    ["Edge harder, loser. That's all you get."],
+    ["No release. Only frustration and obedience."]
   ],
   "pegging": [
-    "Bent over already? That didn\u2019t take long.",
-    "You like it better this way, don\u2019t you?",
-    "She wears the strap \u2014 and the pants."
+    [],
+    ["Bent over already? That didn't take long."],
+    ["You like it better this way, don't you?"],
+    ["She wears the strap — and the pants."]
   ],
   "sissy_training": [
-    "Repeat after me: I\u2019m a pretty, obedient bimbo.",
-    "That bulge isn\u2019t manhood. It\u2019s a punishment.",
-    "You\u2019ll never be her equal \u2014 just her doll."
+    [],
+    ["Repeat after me: I'm a pretty, obedient bimbo."],
+    ["That bulge isn't manhood. It's a punishment."],
+    ["You'll never be her equal — just her doll."]
   ],
   "public_humiliation": [
-    "Everyone can see your shame now.",
-    "Let the world watch your downfall.",
-    "You love being exposed, don\u2019t you?"
+    [],
+    ["Everyone can see your shame now."],
+    ["Let the world watch your downfall."],
+    ["You love being exposed, don't you?"]
   ],
   "used_condom": [
-    "Drinking it straight from the source, are we?",
-    "She didn\u2019t even need you to make that mess.",
-    "Sloppy seconds? You\u2019re lucky to even get that."
+    [],
+    ["Drinking it straight from the source, are we?"],
+    ["She didn't even need you to make that mess."],
+    ["Sloppy seconds? You're lucky to even get that."]
   ],
   "crying_while_cumming": [
-    "Go ahead. Sob your way through it.",
-    "Tears of shame? My favorite finish.",
-    "It\u2019s not pleasure \u2014 it\u2019s punishment."
+    [],
+    ["Go ahead. Sob your way through it."],
+    ["Tears of shame? My favorite finish."],
+    ["It's not pleasure — it's punishment."]
   ],
   "bimbofication": [
-    "No thoughts. Just moans.",
-    "Brains off. Mouth open.",
-    "Think pink. Act dumb. Be useful."
+    [],
+    ["No thoughts. Just moans."],
+    ["Brains off. Mouth open."],
+    ["Think pink. Act dumb. Be useful."]
   ],
   "netorare": [
-    "She found someone better. Of course she did.",
-    "You were never enough. Now watch.",
-    "He\u2019s doing what you couldn\u2019t."
+    [],
+    ["She found someone better. Of course she did."],
+    ["You were never enough. Now watch."],
+    ["He's doing what you couldn't."]
   ],
   "dominatrix": [
-    "You exist to serve. Speak only when owned.",
-    "She says jump, you bark.",
-    "You\u2019re not her equal. You\u2019re her tool."
+    [],
+    ["You exist to serve. Speak only when owned."],
+    ["She says jump, you bark."],
+    ["You're not her equal. You're her tool."]
   ],
   "tentacle_sex": [
-    "You like it messy, don\u2019t you?",
-    "So many limbs. None of them yours.",
-    "You\u2019re the toy \u2014 they\u2019re the masters."
+    [],
+    ["You like it messy, don't you?"],
+    ["So many limbs. None of them yours."],
+    ["You're the toy — they're the masters."]
   ]
 }


### PR DESCRIPTION
## Summary
- add an intensity-aware whisper dispatcher that rotates Azure whisper voices, manages cooldowns, captions, and scroll suppression
- restructure taunt datasets into intensity matrices and wire gallery/tag modules to hydrate and emit event-driven whispers
- surface a whisper intensity control alongside the audio pills and style the caption overlay for the new dispatcher

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68e6024825ec832ca736afc8185d0b0a