### PR TITLE
Implement ambience controller, audio auto-playlists, and gallery virtualization

### DIFF
--- a/data/audio-playlists.json
+++ b/data/audio-playlists.json
@@ -1,0 +1,37 @@
+{
+  "version": "2025-01-05",
+  "playlists": [
+    {
+      "id": "baseline-tease",
+      "label": "Baseline Tease",
+      "intensity": 2,
+      "tags": ["femdom", "humiliation", "tease"],
+      "tracks": [
+        "Affirmations_for_Service_Submissives_by_Mistress_Elswyth_Femdom_Hypnosis_see_notes_KLICKAUD.mp3",
+        "Blank.mp3",
+        "Filthy Habits.mp3"
+      ]
+    },
+    {
+      "id": "soft-spite",
+      "label": "Soft Spite",
+      "intensity": 1,
+      "tags": ["gentle", "confession"],
+      "tracks": [
+        "Girl Factory.mp3",
+        "Layer Zero.mp3"
+      ]
+    },
+    {
+      "id": "severe-overstimulation",
+      "label": "Severe Overstimulation",
+      "intensity": 3,
+      "tags": ["denial", "overstimulation", "punishment"],
+      "tracks": [
+        "Nipples.mp3",
+        "Yes.mp3",
+        "Filthy Habits.mp3"
+      ]
+    }
+  ]
+}

--- a/modules/ambience-controller.js
+++ b/modules/ambience-controller.js
@@ -1,0 +1,222 @@
+const DEFAULT_INTERVAL = 15000;
+const MIN_INTERVAL = 5000;
+const TAG_DECAY = 0.65;
+const MAX_HISTORY_TAGS = 12;
+
+function toArray(setOrArray) {
+  if (!setOrArray) return [];
+  if (Array.isArray(setOrArray)) return setOrArray.slice();
+  if (typeof setOrArray === 'function') {
+    try {
+      const result = setOrArray();
+      return toArray(result);
+    } catch (error) {
+      console.warn('[ambience] failed to resolve tags from function', error);
+      return [];
+    }
+  }
+  if (setOrArray instanceof Set) return Array.from(setOrArray);
+  if (typeof setOrArray[Symbol.iterator] === 'function') {
+    return Array.from(setOrArray);
+  }
+  return [];
+}
+
+function clampInterval(value) {
+  if (!Number.isFinite(value)) return DEFAULT_INTERVAL;
+  return Math.max(MIN_INTERVAL, Math.floor(value));
+}
+
+function normaliseTag(tag) {
+  if (!tag) return '';
+  return String(tag).trim().toLowerCase().replace(/\s+/g, '_');
+}
+
+function buildGalleryWeights(getFilteredArtists) {
+  const weights = new Map();
+  if (typeof getFilteredArtists !== 'function') return weights;
+  try {
+    const artists = getFilteredArtists();
+    if (!Array.isArray(artists) || artists.length === 0) return weights;
+    const sample = artists.slice(0, 80);
+    sample.forEach((artist, index) => {
+      const tags = Array.isArray(artist?.kinkTags) ? artist.kinkTags : [];
+      const bias = Math.max(1, sample.length - index);
+      tags.forEach((tag) => {
+        const key = normaliseTag(tag);
+        if (!key) return;
+        const prev = weights.get(key) || 0;
+        weights.set(key, prev + 1 * bias);
+      });
+    });
+  } catch (error) {
+    console.warn('[ambience] failed to derive gallery weights', error);
+  }
+  return weights;
+}
+
+function mergeWeightMaps(base, incoming) {
+  const result = new Map(base);
+  incoming.forEach((value, key) => {
+    const safeKey = normaliseTag(key);
+    if (!safeKey) return;
+    const prev = result.get(safeKey) || 0;
+    result.set(safeKey, prev + value);
+  });
+  return result;
+}
+
+export function initAmbienceController(options = {}) {
+  const state = {
+    setBackground: typeof options.setBackground === 'function' ? options.setBackground : null,
+    getActiveTags: typeof options.getActiveTags === 'function' ? options.getActiveTags : null,
+    getFilteredArtists: typeof options.getFilteredArtists === 'function' ? options.getFilteredArtists : null,
+    getPaginationInfo: typeof options.getPaginationInfo === 'function' ? options.getPaginationInfo : null,
+    interval: clampInterval(options.interval ?? DEFAULT_INTERVAL),
+    intensity: 2,
+    motion: 'full',
+    tagWeights: new Map(),
+    scheduled: null,
+    idleTimer: null,
+    destroyed: false,
+    lastRun: 0,
+  };
+
+  if (!state.setBackground) {
+    console.warn('[ambience] no setBackground callback provided; aborting controller init');
+    return null;
+  }
+
+  function decayWeights() {
+    const next = new Map();
+    let carried = 0;
+    state.tagWeights.forEach((value, key) => {
+      const decayed = value * TAG_DECAY;
+      if (decayed > 0.01 && carried < MAX_HISTORY_TAGS) {
+        next.set(key, decayed);
+        carried += 1;
+      }
+    });
+    state.tagWeights = next;
+  }
+
+  function bumpTags(activeTags) {
+    decayWeights();
+    const tags = toArray(activeTags);
+    tags.forEach((tag, index) => {
+      const key = normaliseTag(tag);
+      if (!key) return;
+      const rankBias = tags.length - index;
+      const current = state.tagWeights.get(key) || 0;
+      state.tagWeights.set(key, current + 1 + rankBias * 0.35);
+    });
+  }
+
+  function buildPayload(reason) {
+    const snapshot = mergeWeightMaps(
+      state.tagWeights,
+      buildGalleryWeights(state.getFilteredArtists),
+    );
+    const active = typeof state.getActiveTags === 'function' ? toArray(state.getActiveTags()) : [];
+    if (active.length) {
+      active.forEach((tag) => {
+        const key = normaliseTag(tag);
+        if (!key) return;
+        const prev = snapshot.get(key) || 0;
+        snapshot.set(key, prev + 2.5);
+      });
+    }
+    return {
+      reason,
+      tagWeights: snapshot,
+      intensity: state.intensity,
+      motionMode: state.motion,
+      pagination: state.getPaginationInfo ? state.getPaginationInfo() : null,
+    };
+  }
+
+  function clearIdle() {
+    if (state.idleTimer) {
+      clearTimeout(state.idleTimer);
+      state.idleTimer = null;
+    }
+  }
+
+  function scheduleIdle() {
+    clearIdle();
+    state.idleTimer = setTimeout(() => {
+      requestRefresh('idle');
+    }, state.interval);
+  }
+
+  function performRefresh(reason) {
+    if (state.destroyed) return;
+    state.scheduled = null;
+    state.lastRun = Date.now();
+    Promise.resolve()
+      .then(() => state.setBackground(buildPayload(reason)))
+      .catch((error) => {
+        console.warn('[ambience] background refresh failed', error);
+      })
+      .finally(() => {
+        scheduleIdle();
+      });
+  }
+
+  function requestRefresh(reason, { immediate = false } = {}) {
+    if (state.destroyed) return;
+    const now = Date.now();
+    const elapsed = now - state.lastRun;
+    const delay = immediate ? 0 : Math.max(0, state.interval - elapsed);
+    if (state.scheduled) {
+      clearTimeout(state.scheduled);
+    }
+    state.scheduled = setTimeout(() => performRefresh(reason), delay);
+  }
+
+  function handleTagsUpdated(event) {
+    bumpTags(event?.detail?.activeTags || []);
+    requestRefresh('tags');
+  }
+
+  function handleIntensity(event) {
+    const next = Number(event?.detail?.intensity);
+    if (Number.isFinite(next)) {
+      state.intensity = next;
+      requestRefresh('intensity', { immediate: false });
+    }
+  }
+
+  function handleMotion(event) {
+    const mode = event?.detail?.mode;
+    if (mode === 'reduced' || mode === 'full') {
+      state.motion = mode;
+    }
+  }
+
+  document.addEventListener('tags:updated', handleTagsUpdated);
+  document.addEventListener('tts:intensity', handleIntensity);
+  document.addEventListener('motion:change', handleMotion);
+
+  requestRefresh('init', { immediate: true });
+
+  return {
+    refresh(reason = 'manual') {
+      requestRefresh(reason, { immediate: true });
+    },
+    destroy() {
+      if (state.destroyed) return;
+      state.destroyed = true;
+      if (state.scheduled) {
+        clearTimeout(state.scheduled);
+        state.scheduled = null;
+      }
+      clearIdle();
+      document.removeEventListener('tags:updated', handleTagsUpdated);
+      document.removeEventListener('tts:intensity', handleIntensity);
+      document.removeEventListener('motion:change', handleMotion);
+    },
+  };
+}
+
+export default initAmbienceController;

--- a/modules/audio.js
+++ b/modules/audio.js
@@ -9,6 +9,11 @@ let moansMuted = false;
 let moanPlaying = false;
 
 const GLOBAL_MUTE_STORAGE_KEY = 'te.audio.globalMute';
+const PLAYLIST_DATA_URL = 'data/audio-playlists.json';
+const LAST_PLAYLIST_STORAGE_KEY = 'te.audio.playlist';
+const AUTO_PLAYLIST_STORAGE_KEY = 'te.audio.autoPlaylist';
+const INTENSITY_SYNC_STORAGE_KEY = 'te.audio.intensitySync';
+
 let globalMute = false;
 
 // Audio file list
@@ -21,11 +26,22 @@ const FALLBACK_AUDIO_FILES = [
   "Yes.mp3",
 ];
 
+let baseAudioFiles = [...FALLBACK_AUDIO_FILES];
 let audioFiles = [...FALLBACK_AUDIO_FILES];
 let audioFileData = null;
+let playlistData = null;
+let playlists = [];
+let currentPlaylistId = '__all__';
+let autoPlaylistEnabled = true;
+let intensitySyncEnabled = true;
+let motionMode = 'full';
+let currentTTSIntensity = 2;
+let lastKnownTags = [];
 
-let playlistContainer = null;
 let trackSelectEl = null;
+let playlistSelectEl = null;
+let playlistAutoToggle = null;
+let intensitySyncToggle = null;
 
 async function loadAudioFileData() {
   try {
@@ -34,11 +50,13 @@ async function loadAudioFileData() {
       throw new Error(`Failed to load audio files: ${response.status}`);
     }
     audioFileData = await response.json();
-    audioFiles = audioFileData.files.map(file => file.filename);
+    baseAudioFiles = audioFileData.files.map(file => file.filename);
+    audioFiles = baseAudioFiles.slice();
     console.log(`Loaded ${audioFiles.length} audio files from data/audio-files.json`);
     return audioFileData;
   } catch (error) {
     console.warn('Could not load audio file data, using fallback:', error);
+    baseAudioFiles = [...FALLBACK_AUDIO_FILES];
     audioFiles = [...FALLBACK_AUDIO_FILES];
     // Create fallback data structure
     audioFileData = {
@@ -54,6 +72,274 @@ async function loadAudioFileData() {
   }
 }
 
+function normalisePlaylistEntry(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  const id = String(entry.id || entry.slug || entry.label || '').trim();
+  if (!id) return null;
+  const label = String(entry.label || id).trim();
+  const intensity = Number(entry.intensity);
+  const tags = Array.isArray(entry.tags)
+    ? entry.tags.map((tag) => normalizeTagValue(tag)).filter(Boolean)
+    : [];
+  const tracks = normalizeTrackList(entry.tracks || entry.files || []);
+  return {
+    id,
+    label,
+    intensity: Number.isFinite(intensity) ? intensity : null,
+    tags,
+    tracks,
+  };
+}
+
+async function loadPlaylistData() {
+  try {
+    const response = await fetch(PLAYLIST_DATA_URL, { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error(`Failed to load playlists: ${response.status}`);
+    }
+    const payload = await response.json();
+    playlistData = payload;
+    const source = Array.isArray(payload?.playlists) ? payload.playlists : [];
+    playlists = source
+      .map((entry) => normalisePlaylistEntry(entry))
+      .filter(Boolean);
+    return playlists;
+  } catch (error) {
+    console.info('[audio] playlist data unavailable, continuing with defaults', error);
+    playlists = [];
+    playlistData = null;
+    return playlists;
+  }
+}
+
+function getPlaylistById(id) {
+  if (!id) return null;
+  return playlists.find((playlist) => playlist.id === id) || null;
+}
+
+function computePlaylistScore(playlist, { tags = [], intensity = null } = {}) {
+  let score = 0;
+  const activeTags = new Set((tags || []).map((tag) => normalizeTagValue(tag)));
+  if (playlist.tags && playlist.tags.length) {
+    const matches = playlist.tags.filter((tag) => activeTags.has(tag)).length;
+    score += matches * 4;
+  } else {
+    score += 1; // reward general playlists slightly
+  }
+  if (Number.isFinite(intensity) && Number.isFinite(playlist.intensity)) {
+    const diff = Math.abs(Number(playlist.intensity) - Number(intensity));
+    score -= diff * 1.5;
+  }
+  if (playlist.tracks && playlist.tracks.length) {
+    score += playlist.tracks.length * 0.01;
+  }
+  return score;
+}
+
+function renderPlaylistSelector() {
+  if (!playlistSelectEl) return;
+  playlistSelectEl.innerHTML = '';
+  const autoOption = document.createElement('option');
+  autoOption.value = '__auto__';
+  autoOption.textContent = 'Auto (tags & intensity)';
+  playlistSelectEl.appendChild(autoOption);
+
+  const allOption = document.createElement('option');
+  allOption.value = '__all__';
+  allOption.textContent = 'All tracks';
+  playlistSelectEl.appendChild(allOption);
+
+  playlists.forEach((playlist) => {
+    const option = document.createElement('option');
+    option.value = playlist.id;
+    option.textContent = playlist.label;
+    playlistSelectEl.appendChild(option);
+  });
+
+  if (autoPlaylistEnabled) {
+    playlistSelectEl.value = '__auto__';
+  } else {
+    playlistSelectEl.value = currentPlaylistId || '__all__';
+  }
+}
+
+function updatePlaylistToggles() {
+  if (playlistAutoToggle) {
+    playlistAutoToggle.classList.toggle('is-active', autoPlaylistEnabled);
+    playlistAutoToggle.setAttribute('aria-pressed', autoPlaylistEnabled ? 'true' : 'false');
+  }
+  if (intensitySyncToggle) {
+    intensitySyncToggle.classList.toggle('is-active', intensitySyncEnabled);
+    intensitySyncToggle.setAttribute('aria-pressed', intensitySyncEnabled ? 'true' : 'false');
+  }
+  if (playlistSelectEl) {
+    if (autoPlaylistEnabled) {
+      playlistSelectEl.value = '__auto__';
+    } else if (currentPlaylistId) {
+      playlistSelectEl.value = currentPlaylistId;
+    }
+  }
+}
+
+function persistPlaylistPreferences() {
+  try {
+    localStorage.setItem(AUTO_PLAYLIST_STORAGE_KEY, autoPlaylistEnabled ? '1' : '0');
+    localStorage.setItem(INTENSITY_SYNC_STORAGE_KEY, intensitySyncEnabled ? '1' : '0');
+    if (currentPlaylistId && currentPlaylistId !== '__auto__') {
+      localStorage.setItem(LAST_PLAYLIST_STORAGE_KEY, currentPlaylistId);
+    }
+  } catch (error) {
+    // Ignore storage errors
+  }
+}
+
+function hydratePlaylistPreferences() {
+  try {
+    const savedAuto = localStorage.getItem(AUTO_PLAYLIST_STORAGE_KEY);
+    if (savedAuto === '0' || savedAuto === 'false') {
+      autoPlaylistEnabled = false;
+    }
+    const savedIntensity = localStorage.getItem(INTENSITY_SYNC_STORAGE_KEY);
+    if (savedIntensity === '0' || savedIntensity === 'false') {
+      intensitySyncEnabled = false;
+    }
+    const savedPlaylist = localStorage.getItem(LAST_PLAYLIST_STORAGE_KEY);
+    if (savedPlaylist) {
+      currentPlaylistId = savedPlaylist;
+    }
+  } catch (error) {
+    // Ignore storage errors
+  }
+}
+
+function setAutoPlaylistEnabled(enabled) {
+  autoPlaylistEnabled = Boolean(enabled);
+  if (autoPlaylistEnabled) {
+    playlistSelectEl && (playlistSelectEl.value = '__auto__');
+  } else if (currentPlaylistId === '__auto__') {
+    currentPlaylistId = '__all__';
+  }
+  updatePlaylistToggles();
+  persistPlaylistPreferences();
+}
+
+function setIntensitySyncEnabled(enabled) {
+  intensitySyncEnabled = Boolean(enabled);
+  updatePlaylistToggles();
+  persistPlaylistPreferences();
+  updateAudioIntensityVolume();
+}
+
+function updateAudioIntensityVolume() {
+  if (!hypnoAudio) return;
+  if (globalMute) {
+    hypnoAudio.volume = 0;
+    if (moanAudio) moanAudio.volume = 0;
+    return;
+  }
+  const levels = [0.0, 0.35, 0.55, 0.78];
+  const base = levels[Math.max(0, Math.min(levels.length - 1, Math.floor(currentTTSIntensity)))] || 0.55;
+  const motionFactor = motionMode === 'reduced' ? 0.7 : 1;
+  const targetVolume = intensitySyncEnabled ? Math.max(0, Math.min(1, base * motionFactor)) : hypnoAudio.volume;
+  try {
+    hypnoAudio.volume = targetVolume;
+    if (moanAudio) {
+      moanAudio.volume = moansMuted ? 0 : targetVolume * 0.6;
+    }
+  } catch (error) {
+    console.warn('[audio] failed to update volume', error);
+  }
+}
+
+function applyPlaylist(playlistId, { reason = 'manual', preserveTrack = false } = {}) {
+  let nextId = playlistId || '__all__';
+  if (nextId === '__auto__') {
+    nextId = currentPlaylistId;
+  }
+  let nextFiles = baseAudioFiles.slice();
+  const playlist = getPlaylistById(nextId);
+  if (playlist && playlist.tracks.length) {
+    const normalized = playlist.tracks
+      .map((track) => baseAudioFiles.find((file) => file.toLowerCase() === track.toLowerCase()))
+      .filter(Boolean);
+    if (normalized.length > 0) {
+      nextFiles = normalized;
+      currentPlaylistId = playlist.id;
+    } else {
+      currentPlaylistId = '__all__';
+    }
+  } else {
+    currentPlaylistId = '__all__';
+  }
+
+  const currentTrackName = audioFiles[currentTrack];
+  audioFiles = nextFiles;
+  renderTrackSelector();
+
+  if (preserveTrack && currentTrackName) {
+    const existingIndex = audioFiles.findIndex((file) => file === currentTrackName);
+    if (existingIndex >= 0) {
+      currentTrack = existingIndex;
+    } else {
+      currentTrack = 0;
+    }
+  } else {
+    currentTrack = 0;
+  }
+
+  loadTrack(currentTrack);
+  persistPlaylistPreferences();
+  updatePlaylistToggles();
+
+  if (reason === 'auto' && playlistSelectEl) {
+    playlistSelectEl.value = '__auto__';
+  }
+}
+
+function maybeSelectAutoPlaylist({ tags = [], intensity = null } = {}) {
+  if (!autoPlaylistEnabled || playlists.length === 0) return;
+  const candidates = playlists
+    .map((playlist) => ({ playlist, score: computePlaylistScore(playlist, { tags, intensity }) }))
+    .sort((a, b) => b.score - a.score);
+  const best = candidates[0];
+  if (!best || best.score <= 0) {
+    if (currentPlaylistId !== '__all__') {
+      applyPlaylist('__all__', { reason: 'auto', preserveTrack: true });
+    }
+    return;
+  }
+  if (best.playlist.id !== currentPlaylistId || currentPlaylistId === '__all__') {
+    applyPlaylist(best.playlist.id, { reason: 'auto', preserveTrack: true });
+  }
+}
+
+function handleTagsUpdatedForAudio(event) {
+  const tags = Array.isArray(event?.detail?.activeTags)
+    ? event.detail.activeTags.map((tag) => normalizeTagValue(tag))
+    : [];
+  lastKnownTags = tags;
+  maybeSelectAutoPlaylist({ tags, intensity: currentTTSIntensity });
+}
+
+function handleTTSIntensityChange(event) {
+  const intensity = Number(event?.detail?.intensity);
+  if (Number.isFinite(intensity)) {
+    currentTTSIntensity = Math.max(0, Math.min(3, Math.floor(intensity)));
+    if (intensitySyncEnabled) {
+      updateAudioIntensityVolume();
+    }
+    maybeSelectAutoPlaylist({ tags: lastKnownTags, intensity: currentTTSIntensity });
+  }
+}
+
+function handleMotionPreference(event) {
+  const mode = event?.detail?.mode;
+  if (mode === 'reduced' || mode === 'full') {
+    motionMode = mode;
+    updateAudioIntensityVolume();
+  }
+}
+
 function normalizeTrackList(list) {
   if (!Array.isArray(list)) return [];
   const seen = new Set();
@@ -66,6 +352,11 @@ function normalizeTrackList(list) {
     normalized.push(trimmed);
   });
   return normalized;
+}
+
+function normalizeTagValue(tag) {
+  if (!tag) return '';
+  return String(tag).trim().toLowerCase().replace(/\s+/g, '_');
 }
 
 function parsePlaylistAttribute(raw) {
@@ -399,8 +690,19 @@ async function initAudio() {
   moanToggle = document.getElementById("moan-toggle");
   hypnoAudio = document.getElementById("hypnoAudio");
   moanAudio = document.getElementById("moan-audio");
+  playlistSelectEl = document.getElementById("audio-playlist-select");
+  playlistAutoToggle = document.getElementById("playlist-autopilot");
+  intensitySyncToggle = document.getElementById("audio-intensity-sync");
 
   await loadAudioFileData();
+  await loadPlaylistData();
+  hydratePlaylistPreferences();
+  renderPlaylistSelector();
+  updatePlaylistToggles();
+  if (!autoPlaylistEnabled && currentPlaylistId && currentPlaylistId !== '__auto__') {
+    applyPlaylist(currentPlaylistId, { reason: 'init', preserveTrack: true });
+  }
+  maybeSelectAutoPlaylist({ tags: lastKnownTags, intensity: currentTTSIntensity });
   renderTrackSelector();
   syncAudioPanelLayout();
 
@@ -482,6 +784,7 @@ async function initAudio() {
   }
 
   hydrateGlobalMuteFromStorage();
+  updateAudioIntensityVolume();
 
   // Keyboard shortcuts: Space (play/pause), N (next), P (prev), S (shuffle)
   document.addEventListener("keydown", (e) => {
@@ -503,6 +806,39 @@ async function initAudio() {
       e.preventDefault();
     }
   });
+
+  if (playlistSelectEl) {
+    playlistSelectEl.addEventListener('change', (event) => {
+      const value = event.target.value;
+      if (value === '__auto__') {
+        setAutoPlaylistEnabled(true);
+        maybeSelectAutoPlaylist({ tags: lastKnownTags, intensity: currentTTSIntensity });
+      } else {
+        setAutoPlaylistEnabled(false);
+        applyPlaylist(value, { reason: 'manual' });
+      }
+    });
+  }
+
+  if (playlistAutoToggle) {
+    playlistAutoToggle.addEventListener('click', () => {
+      const next = !autoPlaylistEnabled;
+      setAutoPlaylistEnabled(next);
+      if (next) {
+        maybeSelectAutoPlaylist({ tags: lastKnownTags, intensity: currentTTSIntensity });
+      }
+    });
+  }
+
+  if (intensitySyncToggle) {
+    intensitySyncToggle.addEventListener('click', () => {
+      setIntensitySyncEnabled(!intensitySyncEnabled);
+    });
+  }
+
+  document.addEventListener('tags:updated', handleTagsUpdatedForAudio);
+  document.addEventListener('tts:intensity', handleTTSIntensityChange);
+  document.addEventListener('motion:change', handleMotionPreference);
 }
 
 /**

--- a/modules/components/audio-panel.js
+++ b/modules/components/audio-panel.js
@@ -6,6 +6,16 @@ template.innerHTML = `
         <span aria-hidden="true">🎧</span>
         <span id="audio-track-name">No track playing</span>
       </div>
+      <div class="audio-playlist-selector" role="group" aria-label="Ambience playlist">
+        <label class="field-label" for="audio-playlist-select">Ambience</label>
+        <select id="audio-playlist-select" class="voice-style-select" aria-label="Choose ambience playlist">
+          <option value="__auto__">Auto (tags & intensity)</option>
+        </select>
+        <div class="audio-toggle-row">
+          <button id="playlist-autopilot" type="button" class="audio-pill" aria-pressed="true">Auto-match</button>
+          <button id="audio-intensity-sync" type="button" class="audio-pill" aria-pressed="true">Sync intensity</button>
+        </div>
+      </div>
       <div class="audio-track-selector" role="group" aria-label="Track selection">
         <label class="field-label" for="audio-track-select">Select track</label>
         <select id="audio-track-select" class="voice-style-select" aria-label="Choose audio track">

--- a/modules/gallery.js
+++ b/modules/gallery.js
@@ -7,6 +7,7 @@ import {
   getArtistImageCount,
   fetchArtistStyleTags,
   getArtistSlug,
+  getRandomBackgroundImage,
 } from "./api.js";
 import { handleArtistCopy } from "./sidebar.js";
 import { pickThumbnailCandidateUrls } from "./thumbnail-chooser.js";
@@ -27,8 +28,12 @@ function getThumbnailUrl(artist) {
  */
 
 // Gallery state
-const DEFAULT_ARTISTS_PER_PAGE = 200;
-const MAX_PAGES_IN_DOM = 6;
+const VIRTUAL_BATCH_SIZE = 48;
+const MAX_VIRTUAL_CHUNKS = 5;
+const VIRTUAL_OVERSCAN_CHUNKS = 1;
+
+const DEFAULT_ARTISTS_PER_PAGE = VIRTUAL_BATCH_SIZE;
+const MAX_PAGES_IN_DOM = MAX_VIRTUAL_CHUNKS + VIRTUAL_OVERSCAN_CHUNKS;
 
 let filtered = [];
 let isFetching = false;
@@ -42,6 +47,32 @@ const pagination = {
   current: 1,
   perPage: DEFAULT_ARTISTS_PER_PAGE,
   total: 0,
+};
+
+const virtualState = {
+  chunks: [], // [{ id, start, end, node }]
+  nextChunkId: 1,
+  recyclePool: [],
+};
+
+const DEFAULT_AMBIENT_TAGS = [
+  'chastity_cage',
+  'femdom',
+  'humiliation',
+  'sissy_training',
+  'pegging',
+  'denial',
+  'foot_worship',
+  'bondage',
+];
+
+const ambienceState = {
+  currentUrl: null,
+  activeLayer: null,
+  motionModulePromise: null,
+  intensity: 2,
+  motionMode: 'full',
+  lastQuery: 'chastity_cage',
 };
 
 const resolvePerPage = (value) => {
@@ -92,6 +123,7 @@ function setCurrentPage(val) {
 let artistGallery = null;
 let backgroundBlur = null;
 let gallerySentinel = null;
+let galleryStartSentinel = null;
 
 // External dependencies
 let allArtists = [];
@@ -160,6 +192,7 @@ function expireAllPostsCaches() {
 
 function resetGallerySentinel() {
   gallerySentinel = null;
+  galleryStartSentinel = null;
 }
 
 function ensureGallerySentinel() {
@@ -169,14 +202,43 @@ function ensureGallerySentinel() {
     gallerySentinel.id = "gallery-end-sentinel";
     gallerySentinel.className = "gallery-sentinel";
     gallerySentinel.setAttribute("aria-hidden", "true");
+    gallerySentinel.dataset.direction = "forward";
     artistGallery.appendChild(gallerySentinel);
   } else if (artistGallery.lastElementChild !== gallerySentinel) {
     artistGallery.appendChild(gallerySentinel);
+    gallerySentinel.dataset.direction = "forward";
   }
   return gallerySentinel;
 }
+
+function ensureGalleryStartSentinel() {
+  if (!artistGallery) return null;
+  if (!galleryStartSentinel || !artistGallery.contains(galleryStartSentinel)) {
+    galleryStartSentinel = document.createElement("div");
+    galleryStartSentinel.id = "gallery-start-sentinel";
+    galleryStartSentinel.className = "gallery-sentinel";
+    galleryStartSentinel.setAttribute("aria-hidden", "true");
+    galleryStartSentinel.dataset.direction = "backward";
+    artistGallery.insertBefore(galleryStartSentinel, artistGallery.firstChild);
+  } else {
+    galleryStartSentinel.dataset.direction = "backward";
+  }
+  return galleryStartSentinel;
+}
 function removePageFromDom(pageNumber) {
   if (!artistGallery) return;
+  const numeric = Number(pageNumber);
+  if (!Number.isNaN(numeric)) {
+    const index = virtualState.chunks.findIndex((chunk) => chunk.id === numeric);
+    if (index >= 0) {
+      const [chunk] = virtualState.chunks.splice(index, 1);
+      if (chunk) {
+        releaseChunkContainer(chunk);
+        renderedPages.delete(chunk.id);
+      }
+      return;
+    }
+  }
   const cards = artistGallery.querySelectorAll(
     `.artist-card[data-page="${pageNumber}"]`
   );
@@ -203,9 +265,188 @@ function showGalleryEmptyState() {
   resetGallerySentinel();
 }
 
+function resetVirtualState() {
+  if (!artistGallery) return;
+  const existingChunks = virtualState.chunks.slice();
+  existingChunks.forEach((chunk) => {
+    if (chunk?.node && chunk.node.parentNode === artistGallery) {
+      chunk.node.remove();
+    }
+  });
+  virtualState.chunks = [];
+  virtualState.nextChunkId = 1;
+  // Keep a small recycle pool so we can reuse chunk containers without
+  // recreating DOM nodes repeatedly.
+  if (virtualState.recyclePool.length > MAX_VIRTUAL_CHUNKS * 2) {
+    virtualState.recyclePool.length = MAX_VIRTUAL_CHUNKS * 2;
+  }
+}
+
+function getVirtualChunkSize() {
+  const size = Number(artistsPerPage);
+  if (Number.isFinite(size) && size > 0) {
+    return Math.max(12, Math.floor(size));
+  }
+  return VIRTUAL_BATCH_SIZE;
+}
+
+function acquireChunkContainer() {
+  const recycled = virtualState.recyclePool.pop();
+  if (recycled) {
+    recycled.innerHTML = "";
+    return recycled;
+  }
+  const section = document.createElement("section");
+  section.className = "gallery-chunk";
+  section.setAttribute("role", "presentation");
+  return section;
+}
+
+function releaseChunkContainer(chunk) {
+  if (!chunk || !chunk.node) return;
+  chunk.node.innerHTML = "";
+  if (chunk.node.parentNode === artistGallery) {
+    chunk.node.remove();
+  }
+  if (virtualState.recyclePool.length < MAX_VIRTUAL_CHUNKS * 2 + 2) {
+    virtualState.recyclePool.push(chunk.node);
+  }
+}
+
+function updateChunkMetadata(node, { id, start, end }) {
+  if (!node) return;
+  node.dataset.chunkId = String(id);
+  node.dataset.startIndex = String(start);
+  node.dataset.endIndex = String(end);
+}
+
+function appendVirtualChunk(startIndex = null) {
+  if (!artistGallery) return false;
+  const start =
+    startIndex !== null && Number.isFinite(Number(startIndex))
+      ? Math.max(0, Math.floor(Number(startIndex)))
+      : virtualState.chunks.length > 0
+      ? virtualState.chunks[virtualState.chunks.length - 1].end
+      : 0;
+  if (start >= filtered.length) {
+    return false;
+  }
+  const chunkSize = getVirtualChunkSize();
+  const end = Math.min(filtered.length, start + chunkSize);
+  const artistsSlice = filtered.slice(start, end);
+  const container = acquireChunkContainer();
+  const chunkId = virtualState.nextChunkId++;
+  updateChunkMetadata(container, { id: chunkId, start, end });
+  renderArtistCards(artistsSlice, undefined, {
+    chunkId,
+    target: container,
+    annotatePage: false,
+    eager: start === 0,
+  });
+  const sentinel = ensureGallerySentinel();
+  if (sentinel) {
+    artistGallery.insertBefore(container, sentinel);
+  } else {
+    artistGallery.appendChild(container);
+  }
+  virtualState.chunks.push({ id: chunkId, start, end, node: container });
+  renderedPages.add(chunkId);
+  return true;
+}
+
+function prependVirtualChunk() {
+  if (!artistGallery) return false;
+  if (virtualState.chunks.length === 0) {
+    return appendVirtualChunk(0);
+  }
+  const firstChunk = virtualState.chunks[0];
+  const chunkSize = getVirtualChunkSize();
+  const start = Math.max(0, firstChunk.start - chunkSize);
+  if (start >= firstChunk.start) {
+    return false;
+  }
+  const end = Math.min(filtered.length, start + chunkSize);
+  const artistsSlice = filtered.slice(start, end);
+  const container = acquireChunkContainer();
+  const chunkId = virtualState.nextChunkId++;
+  updateChunkMetadata(container, { id: chunkId, start, end });
+  renderArtistCards(artistsSlice, undefined, {
+    chunkId,
+    target: container,
+    annotatePage: false,
+    eager: false,
+  });
+  const startSentinel = ensureGalleryStartSentinel();
+  if (startSentinel && startSentinel.parentNode === artistGallery) {
+    artistGallery.insertBefore(container, startSentinel.nextSibling);
+  } else {
+    artistGallery.insertBefore(container, artistGallery.firstChild);
+  }
+  virtualState.chunks.unshift({ id: chunkId, start, end, node: container });
+  renderedPages.add(chunkId);
+  return true;
+}
+
+function trimVirtualChunks(direction = "forward") {
+  const limit = MAX_VIRTUAL_CHUNKS + VIRTUAL_OVERSCAN_CHUNKS;
+  while (virtualState.chunks.length > limit) {
+    const chunk =
+      direction === "backward"
+        ? virtualState.chunks.pop()
+        : virtualState.chunks.shift();
+    if (chunk) {
+      releaseChunkContainer(chunk);
+      renderedPages.delete(chunk.id);
+    }
+  }
+}
+
+function getVirtualRange() {
+  if (virtualState.chunks.length === 0) {
+    return { start: 0, end: 0 };
+  }
+  return {
+    start: virtualState.chunks[0].start,
+    end: virtualState.chunks[virtualState.chunks.length - 1].end,
+  };
+}
+
+function ensureViewportCoverage() {
+  if (!artistGallery) return;
+  const viewportHeight =
+    window.innerHeight || document.documentElement?.clientHeight || 0;
+  const desiredHeight = viewportHeight * 1.2;
+  let totalHeight = artistGallery.scrollHeight;
+  let guard = 0;
+  while (totalHeight < desiredHeight && guard < MAX_VIRTUAL_CHUNKS + 4) {
+    const appended = appendVirtualChunk();
+    if (!appended) break;
+    guard += 1;
+    totalHeight = artistGallery.scrollHeight;
+  }
+}
+
+function updatePaginationSnapshot() {
+  const total = filtered.length;
+  const chunkSize = getVirtualChunkSize();
+  pagination.perPage = chunkSize;
+  pagination.total = Math.ceil(total / pagination.perPage);
+  const range = getVirtualRange();
+  if (range.end > range.start) {
+    const current = Math.floor(range.start / chunkSize) + 1;
+    const last = Math.max(current, Math.ceil(range.end / chunkSize));
+    pagination.current = current;
+    currentPage = last;
+  } else {
+    pagination.current = 1;
+    currentPage = 1;
+  }
+  totalPages = pagination.total;
+}
+
 function sortCurrentArtists(list = filtered, mode = sortMode) {
   if (!Array.isArray(list) || !list.length) return list;
-  
+
   if (mode === "count") {
     list.sort(
       (a, b) => (b._totalImageCount || 0) - (a._totalImageCount || 0)
@@ -226,41 +467,279 @@ function sortCurrentArtists(list = filtered, mode = sortMode) {
   return list;
 }
 
-/**
- * Sets the background image with a random image
- */
-async function setRandomBackground() {
-  const blur = document.getElementById("background-blur");
-  if (!blur) return;
-  blur.style.transition = "background-image 0.7s ease, opacity 0.7s ease";
-  // Fade out current background
-  blur.style.opacity = "0";
-  setTimeout(async () => {
-    try {
-      if (document.body.classList.contains("incognito-theme")) {
-        blur.style.backgroundImage = "none";
-        blur.style.backgroundColor = "#111";
-      } else {
-        const { getRandomBackgroundImage } = await import("./api.js");
-        const imageUrl = await getRandomBackgroundImage();
-        if (imageUrl) {
-          blur.style.backgroundImage = `url(${imageUrl})`;
-          blur.style.backgroundColor = "";
-        } else {
-          blur.style.backgroundImage = "none";
-          blur.style.backgroundColor = "#111";
-        }
-      }
-    } catch (error) {
-      console.warn("Failed to set random background:", error);
-      blur.style.backgroundImage = "none";
-      blur.style.backgroundColor = "#111";
-    } finally {
-      setTimeout(() => {
-        blur.style.opacity = "0.7";
-      }, 100);
+function normaliseAmbientTag(tag) {
+  if (!tag) return "";
+  return String(tag).trim().toLowerCase().replace(/\s+/g, "_");
+}
+
+function toWeightMap(input) {
+  const map = new Map();
+  if (!input) return map;
+  if (input instanceof Map) {
+    input.forEach((value, key) => {
+      const safeKey = normaliseAmbientTag(key);
+      const numeric = Number(value);
+      if (!safeKey || !Number.isFinite(numeric)) return;
+      map.set(safeKey, numeric);
+    });
+    return map;
+  }
+  if (Array.isArray(input)) {
+    input.forEach((key) => {
+      const safeKey = normaliseAmbientTag(key);
+      if (!safeKey) return;
+      const prev = map.get(safeKey) || 0;
+      map.set(safeKey, prev + 1);
+    });
+    return map;
+  }
+  if (typeof input === "object") {
+    Object.entries(input).forEach(([key, value]) => {
+      const safeKey = normaliseAmbientTag(key);
+      const numeric = Number(value);
+      if (!safeKey || !Number.isFinite(numeric)) return;
+      map.set(safeKey, numeric);
+    });
+    return map;
+  }
+  return map;
+}
+
+function deriveAmbientWeights(tagWeights) {
+  const base = toWeightMap(tagWeights);
+  if (base.size === 0) {
+    const sample = filtered.slice(0, 80);
+    sample.forEach((artist, index) => {
+      const tags = Array.isArray(artist?.kinkTags) ? artist.kinkTags : [];
+      const bias = Math.max(1, sample.length - index);
+      tags.forEach((tag) => {
+        const safeKey = normaliseAmbientTag(tag);
+        if (!safeKey) return;
+        const prev = base.get(safeKey) || 0;
+        base.set(safeKey, prev + 1 * bias);
+      });
+    });
+  }
+  if (base.size === 0) {
+    DEFAULT_AMBIENT_TAGS.forEach((tag, index) => {
+      base.set(tag, DEFAULT_AMBIENT_TAGS.length - index);
+    });
+  }
+  return base;
+}
+
+function selectWeightedTag(weights, excludeTag = null) {
+  const entries = Array.from(weights.entries()).filter(([tag, weight]) => {
+    if (!tag || !Number.isFinite(Number(weight))) return false;
+    if (excludeTag && tag === excludeTag) return false;
+    return Number(weight) > 0;
+  });
+  if (entries.length === 0) return null;
+  const total = entries.reduce((sum, [, value]) => sum + Number(value), 0);
+  let threshold = Math.random() * total;
+  for (const [tag, value] of entries) {
+    threshold -= Number(value);
+    if (threshold <= 0) {
+      return tag;
     }
-  }, 400);
+  }
+  return entries[entries.length - 1][0];
+}
+
+function buildAmbientQuery(weights, intensity = 2) {
+  const sorted = Array.from(weights.entries()).sort((a, b) => b[1] - a[1]);
+  const primary = sorted[0]?.[0] || selectWeightedTag(weights) || DEFAULT_AMBIENT_TAGS[0];
+  const secondaryCandidate = selectWeightedTag(weights, primary);
+  const useSecondary = secondaryCandidate && Math.random() > 0.55;
+  let query = primary;
+  if (useSecondary) {
+    query += `+${secondaryCandidate}`;
+  }
+  const level = Number.isFinite(Number(intensity)) ? Number(intensity) : 2;
+  if (level >= 3) {
+    query += "+rating:explicit";
+  } else if (level <= 1) {
+    query += "+rating:safe";
+  } else {
+    query += "+rating:questionable";
+  }
+  return query;
+}
+
+async function ensureMotionModule() {
+  if (typeof window === "undefined") return null;
+  try {
+    if (
+      window.matchMedia &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      return null;
+    }
+  } catch (error) {
+    // Ignore matchMedia errors
+  }
+  if (!ambienceState.motionModulePromise) {
+    ambienceState.motionModulePromise = import(
+      "https://cdn.jsdelivr.net/npm/motion@10.16.4/+esm"
+    ).catch((error) => {
+      console.warn("[ambience] Motion One import failed", error);
+      return null;
+    });
+  }
+  try {
+    return await ambienceState.motionModulePromise;
+  } catch (error) {
+    console.warn("[ambience] Motion module failed", error);
+    return null;
+  }
+}
+
+async function preloadImage(url) {
+  return new Promise((resolve, reject) => {
+    if (!url) {
+      reject(new Error("Empty ambient url"));
+      return;
+    }
+    const img = new Image();
+    img.decoding = "async";
+    img.onload = () => resolve(url);
+    img.onerror = (err) => reject(err);
+    img.src = url;
+  });
+}
+
+function createAmbientLayer(url) {
+  const layer = document.createElement("div");
+  layer.className = "ambient-layer";
+  layer.style.backgroundImage = `url(${url})`;
+  layer.style.opacity = "0";
+  return layer;
+}
+
+async function applyAmbientLayer(container, url) {
+  if (!container || !url) return;
+  const newLayer = createAmbientLayer(url);
+  container.appendChild(newLayer);
+  const previous = ambienceState.activeLayer;
+  let motionModule = null;
+  if (ambienceState.motionMode !== "reduced") {
+    motionModule = await ensureMotionModule();
+  }
+
+  if (motionModule && typeof motionModule.animate === "function") {
+    const animations = [
+      motionModule
+        .animate(
+          newLayer,
+          {
+            opacity: [0, 0.82],
+            transform: ["scale(1.05)", "scale(1)"],
+            filter: ["blur(8px)", "blur(0px)"],
+          },
+          {
+            duration: 1000,
+            easing: "cubic-bezier(.4,-0.2,.2,1.2)",
+            fill: "forwards",
+          }
+        )
+        .finished.catch(() => {}),
+    ];
+    if (previous) {
+      animations.push(
+        motionModule
+          .animate(
+            previous,
+            {
+              opacity: [Number(previous.style.opacity) || 0.75, 0],
+              filter: ["blur(0px)", "blur(18px)"],
+            },
+            {
+              duration: 800,
+              easing: "ease-out",
+              fill: "forwards",
+            }
+          )
+          .finished.catch(() => {})
+      );
+    }
+    await Promise.all(animations);
+  } else {
+    newLayer.style.opacity = "0.8";
+    if (previous) previous.style.opacity = "0";
+  }
+
+  if (previous && previous !== newLayer) {
+    setTimeout(() => {
+      try {
+        previous.remove();
+      } catch (error) {
+        console.warn("[ambience] failed to remove old layer", error);
+      }
+    }, 240);
+  }
+
+  ambienceState.activeLayer = newLayer;
+  container.classList.add("ambient-layer-container");
+}
+
+/**
+ * Sets the background image based on ambient tag weights.
+ */
+async function setRandomBackground(options = {}) {
+  const blur = document.getElementById('background-blur');
+  if (!blur) return;
+
+  if (document.body?.classList.contains('incognito-theme')) {
+    blur.style.backgroundImage = 'none';
+    blur.style.backgroundColor = '#111';
+    if (ambienceState.activeLayer) {
+      try { ambienceState.activeLayer.remove(); } catch {}
+      ambienceState.activeLayer = null;
+    }
+    return;
+  }
+
+  const { tagWeights, intensity, motionMode } = options;
+  if (Number.isFinite(Number(intensity))) {
+    ambienceState.intensity = Number(intensity);
+  }
+  if (motionMode === 'reduced' || motionMode === 'full') {
+    ambienceState.motionMode = motionMode;
+  }
+
+  const weights = deriveAmbientWeights(tagWeights);
+  const query = buildAmbientQuery(weights, ambienceState.intensity);
+  ambienceState.lastQuery = query;
+
+  let imageUrl = null;
+  try {
+    imageUrl = await getRandomBackgroundImage(query);
+  } catch (error) {
+    console.warn('[ambience] failed to fetch background', error);
+  }
+
+  if (!imageUrl && ambienceState.currentUrl) {
+    imageUrl = ambienceState.currentUrl;
+  }
+
+  if (!imageUrl) {
+    blur.style.backgroundColor = '#111';
+    return;
+  }
+
+  if (imageUrl === ambienceState.currentUrl && ambienceState.activeLayer) {
+    return;
+  }
+
+  try {
+    const loadedUrl = await preloadImage(imageUrl);
+    await applyAmbientLayer(blur, loadedUrl);
+    ambienceState.currentUrl = loadedUrl;
+    blur.style.backgroundImage = 'none';
+    blur.style.backgroundColor = 'transparent';
+  } catch (error) {
+    console.warn('[ambience] failed to apply background', error);
+  }
 }
 
 /**
@@ -894,68 +1373,55 @@ function setArtistsPerPage(count) {
  */
 function renderArtistsPage(options = {}) {
   if (!artistGallery) return;
-  const { force = false } = options;
-  const totalPages = updatePaginationTotals();
-  const maxPage = Math.max(1, totalPages || 0);
-  const current = getCurrentPage();
-  const page = Math.min(current, maxPage);
-  if (page !== current) {
-    setCurrentPage(page);
-  }
-  const start = (page - 1) * artistsPerPage;
+  const { force = false, direction = "forward" } = options;
+  const normalizedDirection =
+    direction === "backward" ? "backward" : "forward";
 
-  if (page === 1) {
+  if (force) {
     artistGallery.innerHTML = "";
     resetGallerySentinel();
+    ensureGalleryStartSentinel();
+    resetVirtualState();
     renderedPages.clear();
-  } else if (force) {
-    removePageFromDom(page);
-  } else if (renderedPages.has(page)) {
-    pruneGalleryPages(page);
-    return;
   }
+
+  removeGalleryEmptyState();
 
   if (filtered.length === 0) {
-    const emptyState = document.createElement("div");
-    emptyState.className = "gallery-empty-state";
-
-    const title = document.createElement("p");
-    title.className = "gallery-empty-state__title";
-    title.textContent = "No artists for that combination";
-    emptyState.appendChild(title);
-
-    const body = document.createElement("p");
-    body.className = "gallery-empty-state__body";
-    body.textContent =
-      "Use the FILTER command above or clear your tags to coax new prey back into view.";
-    emptyState.appendChild(body);
-
-    artistGallery.appendChild(emptyState);
+    showGalleryEmptyState();
+    updatePaginationSnapshot();
     return;
   }
 
-  if (start >= filtered.length) {
-    ensureGallerySentinel();
-    pruneGalleryPages(page);
-    return;
-  }
+  ensureGalleryStartSentinel();
+  ensureGallerySentinel();
 
-  const end = Math.min(start + artistsPerPage, filtered.length);
-  const artistsToShow = filtered.slice(start, end);
+  let rendered = false;
 
-  if (artistsToShow.length > 0) {
-    renderArtistCards(artistsToShow, undefined, page);
-    renderedPages.add(page);
+  if (force) {
+    rendered = appendVirtualChunk(0);
+    ensureViewportCoverage();
+  } else if (normalizedDirection === "backward") {
+    rendered = prependVirtualChunk();
+    trimVirtualChunks("forward");
   } else {
-    // No artists for this page; roll back the page counter and sentinel
-    setCurrentPage(page - 1, { persist: true });
-    ensureGallerySentinel();
-    return;
+    rendered = appendVirtualChunk();
+    trimVirtualChunks("backward");
   }
 
-  pruneGalleryPages(getCurrentPage());
-  
-  // Enhance all gallery images to prevent pixelation
+  if (!rendered && virtualState.chunks.length === 0) {
+    rendered = appendVirtualChunk(0);
+  }
+
+  ensureViewportCoverage();
+  updatePaginationSnapshot();
+
+  if (typeof requestAnimationFrame === "function") {
+    requestAnimationFrame(() => primeVisibleArtistImages());
+  } else {
+    primeVisibleArtistImages();
+  }
+
   setTimeout(() => enhanceGalleryImages(), 50);
 }
 
@@ -1080,17 +1546,32 @@ function initImageObserver() {
 }
 
 // Helper to render a list of artists using the normal card structure
-function renderArtistCards(artists, selectedTagsOverride, pageNumber = 1) {
+function renderArtistCards(artists, selectedTagsOverride, options = 1) {
   if (!artistGallery) return;
-  if (pageNumber > 0 && renderedPages.has(pageNumber)) {
-    removePageFromDom(pageNumber);
+  const config =
+    typeof options === "number"
+      ? { chunkId: options }
+      : options && typeof options === "object"
+      ? options
+      : { chunkId: 1 };
+  const rawChunkId = config.chunkId ?? config.pageNumber ?? 1;
+  const chunkId = Number.isFinite(Number(rawChunkId))
+    ? Number(rawChunkId)
+    : 1;
+  const targetElement =
+    config && config.target instanceof Element ? config.target : artistGallery;
+  const annotatePage = config.annotatePage !== false;
+  const eagerRequested = config.eager === true;
+
+  if (chunkId > 0 && renderedPages.has(chunkId) && targetElement === artistGallery) {
+    removePageFromDom(chunkId);
   }
-  
+
   // Inject image quality CSS if not already done
   injectImageQualityCss();
-  
+
   const frag = document.createDocumentFragment();
-  let eagerBudget = pageNumber === 1 ? 6 : 0; // Reduced from 12 to 6 for less initial load
+  let eagerBudget = eagerRequested || chunkId === 1 ? 6 : 0; // Reduced from 12 to 6 for less initial load
   const selectedTags =
     selectedTagsOverride || (getActiveTags ? Array.from(getActiveTags()) : []);
   const observer = initImageObserver();
@@ -1098,7 +1579,16 @@ function renderArtistCards(artists, selectedTagsOverride, pageNumber = 1) {
   artists.forEach((artist) => {
     const card = document.createElement("div");
     card.className = "artist-card group";
-    card.dataset.page = String(pageNumber);
+    if (annotatePage) {
+      card.dataset.page = String(chunkId);
+    } else {
+      try {
+        card.dataset.page = String(chunkId);
+      } catch (error) {
+        // Ignore dataset assignment errors
+      }
+    }
+    card.dataset.virtualChunk = String(chunkId);
     card.setAttribute("data-artist", artist.artistName);
     const artistSlug = getArtistSlug(artist.artistName);
     if (artistSlug) {
@@ -1316,48 +1806,40 @@ function renderArtistCards(artists, selectedTagsOverride, pageNumber = 1) {
     frag.appendChild(card);
   });
 
-  const sentinel = ensureGallerySentinel();
-  if (sentinel) {
-    artistGallery.insertBefore(frag, sentinel);
+  if (targetElement === artistGallery) {
+    const sentinel = ensureGallerySentinel();
+    if (sentinel) {
+      targetElement.insertBefore(frag, sentinel);
+    } else {
+      targetElement.appendChild(frag);
+    }
+    renderedPages.add(chunkId);
   } else {
-    artistGallery.appendChild(frag);
-  }
-  renderedPages.add(pageNumber);
-  if (typeof requestAnimationFrame === "function") {
-    requestAnimationFrame(() => primeVisibleArtistImages());
-  } else {
-    primeVisibleArtistImages();
+    targetElement.appendChild(frag);
   }
 }
 
 function pruneGalleryPages(currentPage) {
   if (!artistGallery) return;
-  const minimumPage = Math.max(1, currentPage - (MAX_PAGES_IN_DOM - 1));
-  const cards = artistGallery.querySelectorAll(".artist-card[data-page]");
-  const pagesRemoved = new Set();
-  cards.forEach((card) => {
-    const pageValue = parseInt(card.getAttribute("data-page") || "", 10);
-    if (!Number.isNaN(pageValue) && pageValue < minimumPage) {
-      card.remove();
-      pagesRemoved.add(pageValue);
-    }
-  });
-  pagesRemoved.forEach((page) => renderedPages.delete(page));
+  trimVirtualChunks(currentPage && currentPage < pagination.current ? "backward" : "forward");
 }
 
 function getPaginationInfo() {
   const page = getCurrentPage();
   const total = filtered.length;
   const totalPages = getTotalPages();
-  const shown = Math.min(page * pagination.perPage, total);
+  const range = getVirtualRange();
+  const shown = Math.min(range.end, total);
   const lastRenderedPage =
-    renderedPages.size > 0
-      ? Math.max(...renderedPages)
+    virtualState.chunks.length > 0
+      ? virtualState.chunks[virtualState.chunks.length - 1].id
       : Math.max(0, pagination.current);
   return {
     total: total,
     shown: shown,
-    hasMore: totalPages > 0 && page < totalPages,
+    hasMore: totalPages > 0 && range.end < total,
+    hasMoreForward: range.end < total,
+    hasMoreBackward: range.start > 0,
     currentPage: page,
     artistsPerPage: artistsPerPage,
     totalPages,

--- a/modules/pages/gallery.js
+++ b/modules/pages/gallery.js
@@ -37,6 +37,7 @@ import {
   getCurrentPage,
   setCurrentPage,
   renderArtistsPage,
+  getFilteredArtists,
 } from '../gallery.js';
 import { initUI, setupInfiniteScroll, setupBackgroundRotation } from '../ui.js';
 import {
@@ -658,14 +659,24 @@ export async function initGalleryPage({ foldAdapter } = {}) {
   }
 
   initTagExplorer();
-  setupBackgroundRotation(setRandomBackground, 15000);
-  setupInfiniteScroll(() => {
-    const info = getPaginationInfo();
-    if (info && info.hasMore) {
-      setCurrentPage(getCurrentPage() + 1);
-      renderArtistsPage();
-    }
-  }, getPaginationInfo);
+  setupBackgroundRotation(setRandomBackground, {
+    getActiveTags,
+    getFilteredArtists,
+    getPaginationInfo,
+  });
+  setupInfiniteScroll({
+    onForward: () => {
+      const info = getPaginationInfo();
+      if (!info?.hasMoreForward) return;
+      renderArtistsPage({ direction: 'forward' });
+    },
+    onBackward: () => {
+      const info = getPaginationInfo();
+      if (!info?.hasMoreBackward) return;
+      renderArtistsPage({ direction: 'backward' });
+    },
+    infoProvider: () => getPaginationInfo(),
+  });
 
   setupThemeToggle();
   setupTagSearchModeSelector();

--- a/modules/ui.js
+++ b/modules/ui.js
@@ -22,70 +22,106 @@ function showNoEntriesMsg(element, msg = "No valid entries") {
 /**
  * Sets up infinite scroll functionality
  */
-function setupInfiniteScroll(callback, infoProvider) {
+function setupInfiniteScroll(options, legacyInfoProvider) {
   const gallery = document.getElementById("artist-gallery");
-  if (!gallery || typeof callback !== "function") {
-    return;
+  if (!gallery) return;
+
+  let config = options;
+  if (typeof options === "function") {
+    config = {
+      onForward: options,
+      infoProvider: legacyInfoProvider,
+    };
   }
 
-  let loading = false;
-  let currentSentinel = null;
-  let pendingPage = null;
+  if (!config || typeof config !== "object") return;
+
+  const {
+    onForward,
+    onBackward,
+    infoProvider,
+    rootMargin = "30% 0px",
+  } = config;
+
+  if (typeof onForward !== "function") return;
+
+  let forwardLoading = false;
+  let backwardLoading = false;
+  const activeSentinels = new Set();
+
+  const requestStep = (direction) => {
+    const info = typeof infoProvider === "function" ? infoProvider() : null;
+    if (direction === "backward") {
+      if (
+        typeof onBackward !== "function" ||
+        backwardLoading ||
+        !(info?.hasMoreBackward)
+      ) {
+        return;
+      }
+      backwardLoading = true;
+      Promise.resolve(onBackward())
+        .catch((error) => {
+          console.warn("Infinite scroll backward callback failed", error);
+        })
+        .finally(() => {
+          backwardLoading = false;
+        });
+    } else {
+      if (forwardLoading || !(info?.hasMoreForward ?? info?.hasMore)) {
+        return;
+      }
+      forwardLoading = true;
+      Promise.resolve(onForward())
+        .catch((error) => {
+          console.warn("Infinite scroll forward callback failed", error);
+        })
+        .finally(() => {
+          forwardLoading = false;
+        });
+    }
+  };
 
   const observer = new IntersectionObserver(
     (entries) => {
-      const entry = entries[0];
-      if (!entry || !entry.isIntersecting) return;
-      const info = typeof infoProvider === "function" ? infoProvider() : null;
-      if (!info || !info.hasMore || loading) return;
-      if (pendingPage !== null && info.lastRenderedPage < pendingPage) {
-        return;
-      }
-      pendingPage = info.currentPage + 1;
-      loading = true;
-      Promise.resolve(callback())
-        .catch((error) => {
-          console.warn("Infinite scroll callback failed", error);
-        })
-        .finally(() => {
-          loading = false;
-          const latestInfo = typeof infoProvider === "function" ? infoProvider() : null;
-          if (
-            pendingPage !== null &&
-            (
-              !latestInfo ||
-              latestInfo.lastRenderedPage >= pendingPage ||
-              !latestInfo.hasMore ||
-              latestInfo.currentPage < pendingPage
-            )
-          ) {
-            pendingPage = null;
-          }
-        });
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) return;
+        const direction = entry.target?.dataset?.direction || "forward";
+        requestStep(direction === "backward" ? "backward" : "forward");
+      });
     },
     {
       root: null,
-      rootMargin: "35% 0px",
+      rootMargin,
       threshold: 0.01,
     }
   );
 
-  const connectSentinel = () => {
-    const sentinel = document.getElementById("gallery-end-sentinel");
-    if (currentSentinel && (!sentinel || sentinel !== currentSentinel)) {
-      observer.unobserve(currentSentinel);
-      currentSentinel = null;
-    }
-    if (sentinel && sentinel !== currentSentinel) {
-      currentSentinel = sentinel;
-      observer.observe(currentSentinel);
-    }
+  const connectSentinels = () => {
+    const bottom = document.getElementById("gallery-end-sentinel");
+    const top = document.getElementById("gallery-start-sentinel");
+    const targets = [bottom, top].filter((el) => el instanceof Element);
+
+    // Disconnect any removed sentinels
+    activeSentinels.forEach((node) => {
+      if (!node || !node.isConnected || !targets.includes(node)) {
+        observer.unobserve(node);
+        activeSentinels.delete(node);
+      }
+    });
+
+    targets.forEach((node) => {
+      if (!activeSentinels.has(node)) {
+        observer.observe(node);
+        activeSentinels.add(node);
+      }
+    });
   };
 
-  connectSentinel();
+  connectSentinels();
 
   const mutationObserver = new MutationObserver(() => {
-    connectSentinel();
+    connectSentinels();
   });
 
   mutationObserver.observe(gallery, { childList: true });
@@ -93,6 +129,7 @@ function setupInfiniteScroll(callback, infoProvider) {
   window.addEventListener("beforeunload", () => {
     observer.disconnect();
     mutationObserver.disconnect();
+    activeSentinels.clear();
   });
 }
 
@@ -144,11 +181,45 @@ function setupStickyTopBar() {
 /**
  * Sets up random background changes at intervals
  */
-function setupBackgroundRotation(setBackgroundCallback, intervalMs = 15000) {
-  if (setBackgroundCallback) {
-    setBackgroundCallback(); // Set initial background
-    setInterval(setBackgroundCallback, intervalMs);
+async function setupBackgroundRotation(setBackgroundCallback, options = {}) {
+  if (typeof setBackgroundCallback !== 'function') return null;
+
+  let config = options;
+  if (typeof options === 'number') {
+    config = { interval: options };
   }
+  const controllerOptions = {
+    setBackground: setBackgroundCallback,
+    getActiveTags: config?.getActiveTags,
+    getFilteredArtists: config?.getFilteredArtists,
+    getPaginationInfo: config?.getPaginationInfo,
+    interval: typeof config?.interval === 'number' ? config.interval : 15000,
+  };
+
+  try {
+    const module = await import('./ambience-controller.js');
+    if (module?.initAmbienceController) {
+      return module.initAmbienceController(controllerOptions);
+    }
+  } catch (error) {
+    console.warn('Failed to initialize ambience controller, falling back to timer', error);
+  }
+
+  setBackgroundCallback();
+  const interval = controllerOptions.interval;
+  const timer = setInterval(() => {
+    try {
+      setBackgroundCallback();
+    } catch (err) {
+      console.warn('Background rotation fallback failed', err);
+    }
+  }, interval);
+
+  return {
+    dispose() {
+      clearInterval(timer);
+    },
+  };
 }
 
 /**

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -1263,6 +1263,47 @@ transform: translate(-50%, 2.5rem);
 }
 }
 
+@layer components {
+.ambient-layer-container {
+position: relative;
+overflow: hidden;
+isolation: isolate;
+}
+.ambient-layer {
+position: absolute;
+inset: 0;
+background-size: cover;
+background-position: center;
+filter: blur(14px) saturate(1.2);
+transform: scale(1.08);
+mix-blend-mode: screen;
+pointer-events: none;
+will-change: opacity, transform, filter;
+transition: opacity 0.6s ease;
+}
+body.incognito-theme .ambient-layer {
+display: none;
+}
+.audio-playlist-selector {
+@apply flex flex-col gap-2 mb-3;
+}
+.audio-playlist-selector .field-label {
+@apply text-[0.55rem] uppercase tracking-[0.35em] text-slate-300;
+}
+.audio-playlist-selector .voice-style-select {
+@apply w-full;
+}
+.audio-toggle-row {
+@apply mt-2 flex gap-2 flex-wrap;
+}
+.audio-toggle-row .audio-pill {
+@apply text-[0.55rem] tracking-[0.3em];
+}
+.audio-toggle-row .audio-pill.is-active {
+@apply border-glow bg-glow/20 text-white;
+}
+}
+
 @keyframes screenPulse {
 0% { opacity: 1; }
 50% { opacity: 0.6; }


### PR DESCRIPTION
## Summary
- add a tag-reactive ambience controller to drive background imagery and integrate Motion One transitions with gallery updates
- virtualize the gallery grid with chunk recycling and viewport-aware infinite scroll to cut DOM weight while preserving interactions
- expand audio playback with playlist metadata, intensity sync, UI controls, and supporting styles/data updates

## Testing
- npm test *(fails: modules/tts-toggle.js expects DOM for updateIntensityControl)*

------
https://chatgpt.com/codex/tasks/task_e_68e608ac2384832cb5e9b7a8ce98e619