### PR TITLE
Refactor tag explorer toggle binding

### DIFF
--- a/modules/pages/gallery.js
+++ b/modules/pages/gallery.js
@@ -49,7 +49,7 @@ import { startTauntTicker } from '../humiliation.js';
 import { createTTSToggleButton, createTTSIntensityControl } from '../tts-toggle.js';
 import {
   initTagExplorer,
-  openTagExplorer,
+  toggleTagExplorer,
   setAllArtists as setExplorerArtists,
 } from '../tag-explorer.js';
 import { showAzureVoiceSelector } from '../azure-tts.js';
@@ -531,13 +531,10 @@ async function setupFiltersButton() {
   ].filter(Boolean);
   if (!filterButtons.length) return;
 
-  const handleToggle = (event) => {
-    event.preventDefault();
-    openTagExplorer();
-  };
-
   filterButtons.forEach((btn) => {
-    btn.addEventListener('click', handleToggle);
+    if (btn.dataset.tagExplorerToggleBound === 'true') return;
+    btn.addEventListener('click', toggleTagExplorer, { once: false });
+    btn.dataset.tagExplorerToggleBound = 'true';
     btn.setAttribute('aria-expanded', 'false');
   });
 

--- a/modules/tag-explorer.js
+++ b/modules/tag-explorer.js
@@ -557,6 +557,17 @@ function unbindEscapeListener() {
   escapeListener = null;
 }
 
+function toggleTagExplorer(event) {
+  if (event && typeof event.preventDefault === "function") {
+    event.preventDefault();
+  }
+  if (isOpen) {
+    closeTagExplorer();
+  } else {
+    openTagExplorer();
+  }
+}
+
 function openTagExplorer() {
   if (!isInitialized) initTagExplorer();
   if (!filtersButtonEl && typeof document !== "undefined") {
@@ -683,16 +694,6 @@ function initTagExplorer() {
       wrapper.appendChild(filtersButtonEl);
       filterTriggerEl = wrapper;
     }
-    
-    // Bind filter button click event
-    filtersButtonEl.addEventListener("click", (event) => {
-      event.preventDefault();
-      if (isOpen) {
-        closeTagExplorer();
-      } else {
-        openTagExplorer();
-      }
-    });
   }
 
   popoverEl = document.getElementById("tag-filter-popover");
@@ -774,4 +775,4 @@ function initTagExplorer() {
   isInitialized = true;
 }
 
-export { openTagExplorer, initTagExplorer, setAllArtists, getFilteredCounts };
+export { openTagExplorer, initTagExplorer, toggleTagExplorer, setAllArtists, getFilteredCounts };


### PR DESCRIPTION
## Summary
- add a shared tag explorer toggle helper so buttons no longer inline-handle clicks
- wire both desktop and cover filter buttons to the shared toggle while preventing duplicate bindings
- keep aria-expanded attributes and the filters-open body class in sync when the explorer opens or closes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e73d4122b4832cb39663b5f38895aa