### PR TITLE
Align landing ambience with gallery rotation

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,17 +13,7 @@
 </head>
 <body data-page="landing" class="landing-body">
   <div class="landing-background" aria-hidden="true">
-    <div class="landing-montage">
-      <div class="landing-montage__frame landing-montage__frame--alpha">
-        <img src="https://cdn.zele.st/data/NAX/Images/danbooru-artist-tags-v4.5/69_%28tranquilo%29.jpg" alt="" loading="lazy" decoding="async">
-      </div>
-      <div class="landing-montage__frame landing-montage__frame--beta">
-        <img src="https://cdn.zele.st/data/NAX/Images/danbooru-artist-tags-v4.5/4tb_%284tera_byte%29.jpg" alt="" loading="lazy" decoding="async">
-      </div>
-      <div class="landing-montage__frame landing-montage__frame--gamma">
-        <img src="https://cdn.zele.st/data/NAX/Images/danbooru-artist-tags-v4.5/2n5.jpg" alt="" loading="lazy" decoding="async">
-      </div>
-    </div>
+    <div id="background-blur" class="background-lattice" aria-hidden="true"></div>
     <div class="landing-grid"></div>
     <div class="landing-noise"></div>
   </div>

--- a/modules/pages/landing.js
+++ b/modules/pages/landing.js
@@ -1,9 +1,137 @@
+import { setRandomBackground } from '../gallery.js';
+import { setupBackgroundRotation } from '../ui.js';
+
+const MOTION_STORAGE_KEY = 'te.motion.preference';
+const MOTION_DEFAULT = 'full';
+const THEME_STORAGE_KEY = 'theme';
+
+function applySavedTheme() {
+  if (typeof document === 'undefined') return 'fem';
+  const body = document.body;
+  if (!body) return 'fem';
+
+  let savedTheme = null;
+  try {
+    savedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+  } catch {
+    savedTheme = null;
+  }
+
+  if (savedTheme === 'incognito') {
+    body.classList.add('incognito-theme');
+    body.classList.remove('fem-theme');
+    return 'incognito';
+  }
+
+  body.classList.add('fem-theme');
+  body.classList.remove('incognito-theme');
+  return 'fem';
+}
+
+function readMotionPreference() {
+  if (typeof window === 'undefined') return MOTION_DEFAULT;
+  try {
+    const value = window.localStorage.getItem(MOTION_STORAGE_KEY);
+    if (value === 'reduced' || value === 'full') {
+      return value;
+    }
+  } catch {
+    // Ignore storage errors.
+  }
+
+  if (typeof window.matchMedia === 'function') {
+    try {
+      if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        return 'reduced';
+      }
+    } catch {
+      // Ignore media query errors.
+    }
+  }
+
+  return MOTION_DEFAULT;
+}
+
+function applyMotionPreference(mode) {
+  const normalized = mode === 'reduced' ? 'reduced' : 'full';
+
+  if (typeof document !== 'undefined') {
+    try {
+      document.documentElement.dataset.motion = normalized;
+    } catch {}
+    if (document.body) {
+      try {
+        document.body.dataset.motion = normalized;
+      } catch {}
+    }
+  }
+
+  try {
+    window.localStorage.setItem(MOTION_STORAGE_KEY, normalized);
+  } catch {
+    // Ignore storage errors.
+  }
+
+  try {
+    document.dispatchEvent(
+      new CustomEvent('motion:change', { detail: { mode: normalized } }),
+    );
+  } catch {
+    // Ignore dispatch failures.
+  }
+
+  return normalized;
+}
+
+function setupThemeToggles() {
+  const toggles = Array.from(document.querySelectorAll('.theme-toggle'));
+  if (!toggles.length) return;
+
+  toggles.forEach((toggleEl) => {
+    toggleEl.addEventListener('click', () => {
+      const body = document.body;
+      if (!body) return;
+
+      body.classList.toggle('incognito-theme');
+      body.classList.toggle('fem-theme');
+
+      const currentTheme = body.classList.contains('incognito-theme') ? 'incognito' : 'fem';
+      try {
+        window.localStorage.setItem(THEME_STORAGE_KEY, currentTheme);
+      } catch {}
+
+      const motionMode = (document.body && document.body.dataset.motion) || readMotionPreference();
+      Promise.resolve(setRandomBackground({ motionMode })).catch((error) => {
+        console.warn('[landing] failed to refresh background after theme toggle', error);
+      });
+    });
+  });
+}
+
 export async function initLandingPage({ shell }) {
   const audioButton = document.querySelector('[data-landing-audio]');
   let setupPromise = null;
+  let ambienceHandle = null;
 
-  // Initialize background montage rotation
-  initMontage();
+  applySavedTheme();
+  let motionMode = applyMotionPreference(readMotionPreference());
+
+  try {
+    await setRandomBackground({ motionMode });
+  } catch (error) {
+    console.warn('[landing] failed to apply initial ambience', error);
+  }
+
+  try {
+    ambienceHandle = await setupBackgroundRotation(setRandomBackground);
+  } catch (error) {
+    console.warn('[landing] failed to initialise ambience rotation', error);
+  }
+
+  // Ensure listeners created inside ambience controller receive the current mode.
+  motionMode = applyMotionPreference(motionMode);
+
+  setupThemeToggles();
 
   function revealAudioPanel() {
     if (!shell?.audioPanel) return;
@@ -13,28 +141,6 @@ export async function initLandingPage({ shell }) {
       panel.classList.remove('hidden');
       panel.setAttribute('aria-hidden', 'false');
     }
-  }
-
-  function initMontage() {
-    const frames = document.querySelectorAll('.landing-montage__frame');
-    if (frames.length === 0) return;
-
-    let currentIndex = 0;
-    
-    // Show first frame immediately
-    frames[0].style.opacity = '1';
-    
-    // Rotate frames every 4 seconds
-    setInterval(() => {
-      // Fade out current frame
-      frames[currentIndex].style.opacity = '0';
-      
-      // Move to next frame
-      currentIndex = (currentIndex + 1) % frames.length;
-      
-      // Fade in next frame
-      frames[currentIndex].style.opacity = '1';
-    }, 4000);
   }
 
   if (audioButton) {
@@ -63,7 +169,21 @@ export async function initLandingPage({ shell }) {
     });
   }
 
-  return {};
+  return {
+    onDispose() {
+      if (ambienceHandle) {
+        try {
+          if (typeof ambienceHandle.destroy === 'function') {
+            ambienceHandle.destroy();
+          } else if (typeof ambienceHandle.dispose === 'function') {
+            ambienceHandle.dispose();
+          }
+        } catch (error) {
+          console.warn('[landing] failed to dispose ambience controller', error);
+        }
+      }
+    },
+  };
 }
 
 export const initPage = initLandingPage;


### PR DESCRIPTION
## Summary
- replace the landing montage stack with the shared #background-blur ambience container
- reuse the gallery background rotation helpers on the landing page while honoring saved theme and motion preferences
- update landing theme toggles to refresh the shared background and dispose ambience on teardown

## Testing
- npm test *(fails: TypeError in modules/tts-toggle.js when updating intensity toggle during existing tag toggle test)*

------
https://chatgpt.com/codex/tasks/task_e_68e744bf42dc832c8b942d53cd00362d