### PR TITLE
Replace favorites alert with humiliation toast

### DIFF
--- a/modules/pages/gallery.js
+++ b/modules/pages/gallery.js
@@ -39,7 +39,12 @@ import {
   renderArtistsPage,
   getFilteredArtists,
 } from '../gallery.js';
-import { initUI, setupInfiniteScroll, setupBackgroundRotation } from '../ui.js';
+import {
+  initUI,
+  setupInfiniteScroll,
+  setupBackgroundRotation,
+  showToast,
+} from '../ui.js';
 import {
   loadAppData,
   persistGalleryState,
@@ -179,7 +184,13 @@ async function setupFavoritesButton() {
     const { getFavoritesCount } = await import('../favorites.js');
 
     if (getFavoritesCount() === 0) {
-      alert('No favorite artists yet. Star some artists first!');
+      showToast('No trophies on your wall yet. Go star someone before begging.', 4200);
+      // Ensure the command bar button keeps focus for keyboard users
+      requestAnimationFrame(() => {
+        if (typeof favoritesBtn.focus === 'function') {
+          favoritesBtn.focus({ preventScroll: true });
+        }
+      });
       return;
     }
 


### PR DESCRIPTION
## Summary
- replace the blocking favorites alert with a humiliation-themed toast that reuses the shared UI helper
- ensure the favorites command button retains focus so keyboard navigation remains uninterrupted

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e75246c504832c9d092d6e63e0c90a