### PR TITLE
Invoke humiliation overlay after gallery updates

### DIFF
--- a/modules/gallery.js
+++ b/modules/gallery.js
@@ -125,6 +125,18 @@ let backgroundBlur = null;
 let gallerySentinel = null;
 let galleryStartSentinel = null;
 
+function triggerGalleryHumiliationPatch() {
+  if (typeof window === "undefined") return;
+  const patch = window._galleryHumiliationPatch;
+  if (typeof patch === "function") {
+    try {
+      patch();
+    } catch (error) {
+      // Swallow errors to avoid breaking gallery rendering if the helper fails
+    }
+  }
+}
+
 // External dependencies
 let allArtists = [];
 let getActiveTags = null;
@@ -265,6 +277,7 @@ function showGalleryEmptyState() {
   artistGallery.appendChild(empty);
   renderedPages.clear();
   resetGallerySentinel();
+  triggerGalleryHumiliationPatch();
 }
 
 function resetVirtualState() {
@@ -1416,6 +1429,10 @@ function renderArtistsPage(options = {}) {
 
   if (!rendered && virtualState.chunks.length === 0) {
     rendered = appendVirtualChunk(0);
+  }
+
+  if (rendered) {
+    triggerGalleryHumiliationPatch();
   }
 
   ensureViewportCoverage();


### PR DESCRIPTION
## Summary
- call the optional humiliation overlay helper whenever new gallery chunks render
- trigger the helper for the empty state so overlays refresh after clearing the grid

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e75406452c832c893c4a67cfd5597d