### PR TITLE
Ensure custom audio tracks update humiliation meter

### DIFF
--- a/modules/audio.js
+++ b/modules/audio.js
@@ -43,6 +43,102 @@ let playlistSelectEl = null;
 let playlistAutoToggle = null;
 let intensitySyncToggle = null;
 
+const CUSTOM_TRACK_PREFIX = 'custom-track';
+
+function getCustomAudioRegistry() {
+  if (typeof window === 'undefined') return null;
+  if (!window._customAudioUrls) {
+    window._customAudioUrls = {};
+  }
+  return window._customAudioUrls;
+}
+
+function findCustomTrackKeyByUrl(url) {
+  const registry = getCustomAudioRegistry();
+  if (!registry) return null;
+  const keys = Object.keys(registry);
+  for (let i = 0; i < keys.length; i += 1) {
+    const entry = registry[keys[i]];
+    if (typeof entry === 'string' && entry === url) {
+      return keys[i];
+    }
+    if (entry && typeof entry === 'object' && entry.url === url) {
+      return keys[i];
+    }
+  }
+  return null;
+}
+
+function deriveLabelFromUrl(url) {
+  if (!url) return 'Custom track';
+  try {
+    const sanitizedUrl = url.split('?')[0].split('#')[0];
+    const fileName = sanitizedUrl.split('/').pop();
+    if (!fileName) return 'Custom track';
+    const decoded = decodeURIComponent(fileName);
+    return decoded
+      .replace(/\.[^/.]+$/, '')
+      .replace(/[_-]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim() || 'Custom track';
+  } catch (error) {
+    console.warn('[audio] failed to derive custom track label', error);
+    return 'Custom track';
+  }
+}
+
+function registerCustomAudioUrl(url) {
+  const normalizedUrl = url.trim();
+  const registry = getCustomAudioRegistry();
+  if (!registry || !normalizedUrl) return null;
+  const existingKey = findCustomTrackKeyByUrl(normalizedUrl);
+  if (existingKey) {
+    return existingKey;
+  }
+  const key = `${CUSTOM_TRACK_PREFIX}-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 6)}`;
+  registry[key] = {
+    url: normalizedUrl,
+    label: deriveLabelFromUrl(normalizedUrl),
+    addedAt: Date.now(),
+  };
+  return key;
+}
+
+function getCustomTrackEntry(key) {
+  if (typeof window === 'undefined') return null;
+  const registry = window._customAudioUrls;
+  if (!registry || !key) return null;
+  const value = registry[key];
+  if (!value) return null;
+  if (typeof value === 'string') {
+    return {
+      key,
+      url: value,
+      label: deriveLabelFromUrl(value),
+    };
+  }
+  if (typeof value === 'object' && value.url) {
+    return {
+      key,
+      url: value.url,
+      label: value.label || deriveLabelFromUrl(value.url),
+    };
+  }
+  return null;
+}
+
+function ensureCustomTracksAppended() {
+  const registry = getCustomAudioRegistry();
+  if (!registry) return;
+  const customKeys = Object.keys(registry);
+  if (!customKeys.length) return;
+  const missingKeys = customKeys.filter((key) => !audioFiles.includes(key));
+  if (!missingKeys.length) return;
+  audioFiles = audioFiles.concat(missingKeys);
+}
+
 // Detect if we're in a subdirectory and need path prefix
 function getPathPrefix() {
   const audioPanel = document.querySelector('te-audio-panel');
@@ -291,6 +387,7 @@ function applyPlaylist(playlistId, { reason = 'manual', preserveTrack = false } 
 
   const currentTrackName = audioFiles[currentTrack];
   audioFiles = nextFiles;
+  ensureCustomTracksAppended();
   renderTrackSelector();
 
   if (preserveTrack && currentTrackName) {
@@ -311,6 +408,7 @@ function applyPlaylist(playlistId, { reason = 'manual', preserveTrack = false } 
   if (reason === 'auto' && playlistSelectEl) {
     playlistSelectEl.value = '__auto__';
   }
+  updateAudioHumiliationMeter();
 }
 
 function maybeSelectAutoPlaylist({ tags = [], intensity = null } = {}) {
@@ -406,7 +504,12 @@ function isRemoteTrack(name) {
 
 function getTrackLabel(name) {
   if (!name) return "Untitled";
-  
+
+  const customEntry = getCustomTrackEntry(name);
+  if (customEntry && customEntry.label) {
+    return customEntry.label;
+  }
+
   // Try to find the title from audioFileData first
   if (audioFileData && audioFileData.files) {
     const fileData = audioFileData.files.find(file => file.filename === name);
@@ -525,8 +628,9 @@ function getAudioSrc(index) {
   if (name.startsWith("./audio/")) {
     return `${prefix}${name.slice(2)}`;
   }
-  if (window._customAudioUrls && window._customAudioUrls[name]) {
-    return window._customAudioUrls[name];
+  const customEntry = getCustomTrackEntry(name);
+  if (customEntry && customEntry.url) {
+    return customEntry.url;
   }
   return `${prefix}audio/${name}`;
 }
@@ -721,6 +825,7 @@ async function initAudio() {
     applyPlaylist(currentPlaylistId, { reason: 'init', preserveTrack: true });
   }
   maybeSelectAutoPlaylist({ tags: lastKnownTags, intensity: currentTTSIntensity });
+  ensureCustomTracksAppended();
   renderTrackSelector();
   syncAudioPanelLayout();
 
@@ -929,13 +1034,28 @@ function addTrackByUrl(url) {
     return;
   }
 
-  // Add to audioFiles array and update current track
   const normalizedUrl = url.trim();
-  audioFiles.push(normalizedUrl);
-  currentTrack = audioFiles.length - 1;
+  const customKey = registerCustomAudioUrl(normalizedUrl);
+  if (!customKey) {
+    showAudioToast("Couldn't store that track right now.", "error");
+    return;
+  }
+
+  const alreadyInPlaylist = audioFiles.includes(customKey);
+  ensureCustomTracksAppended();
+  if (!alreadyInPlaylist && !audioFiles.includes(customKey)) {
+    audioFiles.push(customKey);
+  }
+  currentTrack = audioFiles.indexOf(customKey);
   renderTrackSelector();
   loadTrack(currentTrack);
-  showAudioToast(`Track added: ${getTrackLabel(normalizedUrl)}`, "success");
+  const label = getTrackLabel(customKey);
+  if (alreadyInPlaylist) {
+    showAudioToast(`Track added: ${label} (already added)`, "info");
+  } else {
+    showAudioToast(`Track added: ${label}`, "success");
+  }
+  updateAudioHumiliationMeter();
 }
 
 /**
@@ -1052,9 +1172,8 @@ function updateAudioHumiliationMeter() {
     meter.style.width = "auto";
     meter.style.maxWidth = "320px";
   }
-  const count =
-    (window._customAudioUrls && Object.keys(window._customAudioUrls).length) ||
-    0;
+  const registry = getCustomAudioRegistry();
+  const count = registry ? Object.keys(registry).length : 0;
   const bar = meter.querySelector(".audio-humiliation-bar");
   const taunt = meter.querySelector(".audio-humiliation-taunt");
   const percent = Math.min(100, count * 10);
@@ -1062,11 +1181,19 @@ function updateAudioHumiliationMeter() {
   bar.style.background =
     percent > 80 ? "#fd7bc5" : percent > 50 ? "#ff63a5" : "#f9badd";
   let msg = "";
-  if (count === 0) msg = "Audio dignity: Intact (for now)";
-  else if (count < 3) msg = "Mildly desperate for new tracks";
-  else if (count < 6) msg = "Getting needy for variety...";
-  else if (count < 10) msg = "Desperation rising! So many tracks!";
-  else msg = "Utterly shameless audio addict!";
+  if (count === 0) {
+    msg = "Audio dignity: Intact (for now).";
+  } else if (count === 1) {
+    msg = "One forbidden track? You just couldn't resist.";
+  } else if (count < 4) {
+    msg = `${count} custom cravings already? You're slipping.`;
+  } else if (count < 7) {
+    msg = `${count} stray moans queued. Building a whole shrine, huh?`;
+  } else if (count < 10) {
+    msg = `${count} custom tracks. That hunger is getting loud.`;
+  } else {
+    msg = `${count} custom tracks. You're practically begging for exposure.`;
+  }
   taunt.textContent = msg;
   // --- Show/hide logic ---
   meter.style.opacity = "0.95";


### PR DESCRIPTION
## Summary
- add a registry for custom audio URLs so the meter can see custom additions
- update custom-track add flows to record entries, keep them in playlists, and refresh the meter
- refresh the humiliation meter on playlist changes and refine the escalating taunts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e759b7480c832cb28e8e8e12031881