### PR TITLE
Speed up batched API fetches

### DIFF
--- a/modules/api.js
+++ b/modules/api.js
@@ -27,7 +27,7 @@ let artistsListPromise = null;
 // Rate limiting configuration
 const RATE_LIMIT_CONFIG = {
   // Ultra-fast for maximum responsiveness
-  minDelay: 50, // Minimum 50ms between requests (very fast throughput)
+  minDelay: 35, // Minimum 35ms between requests (even faster throughput)
   maxDelay: 5000, // Maximum 5s delay for backoff
   maxRetries: 4, // allow an extra retry before failing
   backoffMultiplier: 1.5, // moderate backoff multiplier
@@ -569,7 +569,7 @@ async function fetchArtistImages(artistName, selectedTags = [], options = {}) {
  * Batch fetch multiple artist images with staggered requests
  */
 async function fetchArtistImagesBatch(requests, options = {}) {
-  const { batchDelay = 150, maxConcurrent = 6 } = options;
+  const { batchDelay = 90, maxConcurrent = 6 } = options;
   const results = new Map();
   
   // Process requests in smaller concurrent batches
@@ -832,7 +832,7 @@ async function fetchAllArtistImages(
         requests.push({ artistName, selectedTags, options: { limit: LIMIT, page: p, order: ORDER }, key: `p${p}` });
       }
 
-      const batchResults = await fetchArtistImagesBatch(requests, { batchDelay: options.batchDelay || 100, maxConcurrent: options.maxConcurrent || 8 });
+      const batchResults = await fetchArtistImagesBatch(requests, { batchDelay: options.batchDelay || 75, maxConcurrent: options.maxConcurrent || 8 });
       for (let p = 1; p <= totalPages; p++) {
         const key = `p${p}`;
         const pagePosts = batchResults.get(key) || [];

--- a/modules/gallery.js
+++ b/modules/gallery.js
@@ -1122,7 +1122,7 @@ async function openArtistZoom(artist) {
         }
       }
 
-      const newPosts = await api.fetchAllArtistImages(artist.artistName, [], { order: 'approvals', parallel: true, maxConcurrent: 4, batchDelay: 300 });
+      const newPosts = await api.fetchAllArtistImages(artist.artistName, [], { order: 'approvals', parallel: true, maxConcurrent: 4, batchDelay: 150 });
 
       if (Array.isArray(newPosts) && newPosts.length > 0) {
         console.debug(`[gallery] network fetchAllArtistImages loaded ${newPosts.length} posts for ${artist.artistName}`);
@@ -2030,8 +2030,8 @@ async function filterArtists(reset = true, force = false) {
     // Always fetch counts for the current filtered artists (in background)
     async function fetchInBatches(
       artists,
-      batchSize = 10,
-      delayMs = 500,
+      batchSize = 20,
+      delayMs = 250,
       gen,
       spin
     ) {
@@ -2040,7 +2040,7 @@ async function filterArtists(reset = true, force = false) {
         if (gen !== filterGeneration) return;
         const batch = artists.slice(i, i + batchSize);
         
-        // Process batch in parallel (10 artists at once)
+        // Process batch in parallel (20 artists at once)
         await Promise.all(
           batch.map(async (artist) => {
             if (gen !== filterGeneration) return;
@@ -2090,7 +2090,7 @@ async function filterArtists(reset = true, force = false) {
 
     // Initial render already happened above, start fetching counts in background
     if (reset) {
-      await fetchInBatches(filtered, 10, 500, generation, spinner).catch(
+      await fetchInBatches(filtered, 20, 250, generation, spinner).catch(
         (e) => {
           console.error("Batch fetch failed:", e);
         }
@@ -2101,7 +2101,7 @@ async function filterArtists(reset = true, force = false) {
       renderArtistsPage({ force: true });
       window.scrollTo({ top: resetScrollY, behavior: 'instant' });
     } else if (force) {
-      fetchInBatches(filtered, 10, 500, generation, spinner).then(() => {
+      fetchInBatches(filtered, 20, 250, generation, spinner).then(() => {
         if (generation !== filterGeneration) return;
         const forceScrollY = window.scrollY;
         sortCurrentArtists();


### PR DESCRIPTION
## Summary
- reduce the minimum API throttle interval to increase fetch responsiveness
- speed up batched artist image requests by default and update gallery fetch delay
- allow gallery background count updates to process 20 artists at a time with a shorter pause

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e9c576b6a8832c85ed7b5983490084