### PR TITLE
Introduce landing mission ritual with mission_confirm whispers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ A modern, visually unified web app for exploring, filtering, and discovering art
 2. Open `index.html` in your browser
 3. Explore artists, tags, and sidebar features
 
+## Landing Ritual & Mission Storage
+
+- The landing page now opens with a whisper ritual that locks the **Enter Gallery** call-to-action until you pick a mission profile, consent to local logging, and confirm the choice.
+- Once confirmed, TagExplorer stores the mission metadata in `localStorage` under the key `te.mission.profile` with the mission id, display label, description copy, and a UNIX timestamp.
+- A `landing:mission-set` `CustomEvent` is dispatched on `document` after the ritual resolves so other modules can react (e.g., updating UI states or scheduling whispers). Azure TTS also emits a `mission_confirm` whisper when available.
+- The data never leaves your machine. To reset the ritual, clear that key via the browser console (`localStorage.removeItem('te.mission.profile')`) or delete the entry from Application Storage tools, then refresh the page.
+
 ## Customization
 
 - Add new tags or artists by editing the JSON files

--- a/data/tts_lines.json
+++ b/data/tts_lines.json
@@ -88,5 +88,20 @@
       "Tried to escape. Came crawling back. I knew you would.",
       "Door swings shut behind you. You're staying."
     ]
+  ],
+  "mission_confirm": [
+    [],
+    [
+      "Mission logged. The whispers will remind you why you came.",
+      "Profile sealed. Every visit echoes that choice."
+    ],
+    [
+      "Consider it notarised. Your mission glows in our private ledger now.",
+      "Stamp applied. Expect the gallery to purr your title back at you."
+    ],
+    [
+      "The ritual brands you. From now on the site greets you by that hunger.",
+      "Confession saved. I'll recite your mission every time you crawl home."
+    ]
   ]
 }

--- a/index.html
+++ b/index.html
@@ -33,7 +33,13 @@
       <h1 id="landing-title" class="landing-title" data-shadow="Whisper Protocol Engaged">Whisper Protocol Engaged</h1>
       <p class="landing-intro">Each tap leaves a trace. Every filter, every tag — archived, mocked, replayed in soft hisses. Step through if the shame-glow is what you wanted.</p>
       <div class="landing-actions">
-        <a class="landing-cta landing-enter" href="./gallery/" data-router-link data-glitch-trigger>Enter Gallery</a>
+        <a
+          class="landing-cta landing-enter"
+          href="./gallery/"
+          data-router-link
+          data-glitch-trigger
+          data-landing-enter
+        >Enter Gallery</a>
         <button class="landing-cta landing-audio" data-landing-audio type="button">Unmute the whispers</button>
       </div>
       <div class="landing-disclaimer" role="note">
@@ -44,6 +50,89 @@
       <p>Galaxy Z Fold4 tuned. Local storage captures your filter guilt. Proceeding implies consent to gentle torment.</p>
     </footer>
   </div>
+  <dialog
+    data-landing-ritual
+    aria-labelledby="landing-ritual-title"
+    aria-describedby="landing-ritual-copy"
+    aria-modal="true"
+    tabindex="-1"
+  >
+    <div class="landing-ritual__panel" role="document">
+      <div class="landing-ritual__header">
+        <p class="landing-ritual__eyebrow" aria-live="polite">Initiation sequence</p>
+        <h2 id="landing-ritual-title" class="landing-ritual__title">Mission ritual</h2>
+      </div>
+      <div class="landing-ritual__body">
+        <section data-ritual-step="mission" class="landing-ritual__stage">
+          <p id="landing-ritual-copy" class="landing-ritual__lead">
+            Pick the profile you want logged before we let you back inside. Choose carefully – it brands every visit.
+          </p>
+          <ul class="landing-ritual__options" role="list">
+            <li>
+              <button
+                type="button"
+                data-mission-option="cataloguer"
+                data-mission-label="Cataloguer"
+                data-mission-copy="You index every indulgence. A librarian of lust."
+                class="landing-ritual__option"
+              >
+                <span class="landing-ritual__option-title">Cataloguer</span>
+                <span class="landing-ritual__option-copy">You index every indulgence. A librarian of lust.</span>
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                data-mission-option="scout"
+                data-mission-label="Scout"
+                data-mission-copy="Always just checking the feed. Never innocent."
+                class="landing-ritual__option"
+              >
+                <span class="landing-ritual__option-title">Scout</span>
+                <span class="landing-ritual__option-copy">Always "just checking" the feed. Never innocent.</span>
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                data-mission-option="supplicant"
+                data-mission-label="Supplicant"
+                data-mission-copy="You arrive needy, ready to be read aloud."
+                class="landing-ritual__option"
+              >
+                <span class="landing-ritual__option-title">Supplicant</span>
+                <span class="landing-ritual__option-copy">You arrive needy, ready to be read aloud.</span>
+              </button>
+            </li>
+          </ul>
+        </section>
+        <section data-ritual-step="consent" class="landing-ritual__stage" hidden>
+          <p class="landing-ritual__lead">
+            We cache your choice locally. No servers. No mercy if you forget it&apos;s there.
+          </p>
+          <ul class="landing-ritual__bullet-list">
+            <li>Mission + timestamp live in your browser only.</li>
+            <li>Clearing storage resets the ritual and our whispers.</li>
+            <li>Back out now and the door stays sealed.</li>
+          </ul>
+          <div class="landing-ritual__actions">
+            <button type="button" data-ritual-back class="landing-ritual__secondary">Change mission</button>
+            <button type="button" data-ritual-consent class="landing-ritual__primary">Swear me in</button>
+          </div>
+        </section>
+        <section data-ritual-step="confirm" class="landing-ritual__stage" hidden>
+          <p class="landing-ritual__lead" data-ritual-summary>
+            Mission ready. Confirm to let the gallery whisper about it every time you return.
+          </p>
+          <p class="landing-ritual__disclosure">Your consent is recorded in localStorage as <code>te.mission.profile</code>.</p>
+          <div class="landing-ritual__actions">
+            <button type="button" data-ritual-back class="landing-ritual__secondary">Second thoughts</button>
+            <button type="button" data-ritual-confirm class="landing-ritual__primary">Enter under watch</button>
+          </div>
+        </section>
+      </div>
+    </div>
+  </dialog>
   <te-audio-panel data-landing-panel hidden></te-audio-panel>
   <script type="module" src="main.js"></script>
 </body>

--- a/modules/pages/landing.js
+++ b/modules/pages/landing.js
@@ -1,9 +1,322 @@
 import { setRandomBackground } from '../gallery.js';
 import { setupBackgroundRotation } from '../ui.js';
+import { dispatchWhisperEvent } from '../tts-dispatcher.js';
 
 const MOTION_STORAGE_KEY = 'te.motion.preference';
 const MOTION_DEFAULT = 'full';
 const THEME_STORAGE_KEY = 'theme';
+const MISSION_STORAGE_KEY = 'te.mission.profile';
+const CTA_LOCKED_CLASS = 'landing-enter--locked';
+
+function parseMissionProfile(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    const mission = typeof parsed.mission === 'string' ? parsed.mission.trim() : '';
+    const timestamp = Number(parsed.timestamp);
+    if (!mission || !Number.isFinite(timestamp)) return null;
+    const label = typeof parsed.label === 'string' ? parsed.label.trim() : mission;
+    const copy = typeof parsed.copy === 'string' ? parsed.copy.trim() : '';
+    return { mission, label, copy, timestamp };
+  } catch {
+    return null;
+  }
+}
+
+function loadMissionProfile() {
+  if (typeof window === 'undefined') return null;
+  try {
+    const value = window.localStorage.getItem(MISSION_STORAGE_KEY);
+    return parseMissionProfile(value);
+  } catch {
+    return null;
+  }
+}
+
+function persistMissionProfile(profile) {
+  if (typeof window === 'undefined') return;
+  if (!profile || typeof profile !== 'object') return;
+  try {
+    const payload = {
+      mission: profile.mission,
+      label: profile.label,
+      copy: profile.copy,
+      timestamp: profile.timestamp,
+    };
+    window.localStorage.setItem(MISSION_STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    console.warn('[landing] failed to persist mission profile', error);
+  }
+}
+
+function trapFocusWithin(container) {
+  if (!container) return () => {};
+  const handleKeyDown = (event) => {
+    if (event.key !== 'Tab') return;
+    const focusable = Array.from(
+      container.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      ),
+    ).filter(
+      (element) =>
+        !element.hasAttribute('disabled') &&
+        element.getAttribute('aria-hidden') !== 'true' &&
+        element.tabIndex !== -1,
+    );
+    if (!focusable.length) {
+      event.preventDefault();
+      container.focus({ preventScroll: true });
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+    if (event.shiftKey) {
+      if (active === first || !container.contains(active)) {
+        event.preventDefault();
+        last.focus({ preventScroll: true });
+      }
+    } else if (active === last) {
+      event.preventDefault();
+      first.focus({ preventScroll: true });
+    }
+  };
+  container.addEventListener('keydown', handleKeyDown);
+  return () => {
+    container.removeEventListener('keydown', handleKeyDown);
+  };
+}
+
+function setupMissionRitual() {
+  if (typeof document === 'undefined') return null;
+  const dialog = document.querySelector('[data-landing-ritual]');
+  const enterLink = document.querySelector('[data-landing-enter]');
+  if (!dialog || !enterLink) return null;
+  dialog.setAttribute('aria-hidden', 'true');
+  const scheduleFrame =
+    typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function'
+      ? window.requestAnimationFrame.bind(window)
+      : (callback) => setTimeout(callback, 16);
+
+  let focusTrapDisposer = null;
+  let selectedMission = null;
+  let selectedLabel = null;
+  let selectedCopy = null;
+  let activeStep = 'mission';
+  let ritualComplete = false;
+  const summaryEl = dialog.querySelector('[data-ritual-summary]');
+  const missionButtons = Array.from(dialog.querySelectorAll('[data-mission-option]'));
+  const backButtons = Array.from(dialog.querySelectorAll('[data-ritual-back]'));
+  const consentButton = dialog.querySelector('[data-ritual-consent]');
+  const confirmButton = dialog.querySelector('[data-ritual-confirm]');
+  const handleCancel = (event) => {
+    if (ritualComplete) return;
+    event.preventDefault();
+    focusCurrentStep();
+  };
+  const handleClose = () => {
+    if (ritualComplete) return;
+    scheduleFrame(() => {
+      if (!ritualComplete) {
+        openRitual(activeStep);
+      }
+    });
+  };
+  const blockLinkActivation = (event) => {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    event.stopPropagation();
+    openRitual();
+  };
+
+  function setStep(step) {
+    activeStep = step;
+    const stages = Array.from(dialog.querySelectorAll('[data-ritual-step]'));
+    stages.forEach((stage) => {
+      const key = stage.getAttribute('data-ritual-step');
+      const isActive = key === step;
+      stage.toggleAttribute('hidden', !isActive);
+      stage.classList.toggle('landing-ritual__stage--active', isActive);
+    });
+    dialog.setAttribute('data-ritual-stage', step);
+    queueMicrotask(() => focusCurrentStep());
+  }
+
+  function formatSummary() {
+    if (!summaryEl) return;
+    if (!selectedMission) {
+      summaryEl.textContent = 'Mission ready. Confirm to let the gallery whisper about it every time you return.';
+      return;
+    }
+    const label = selectedLabel || selectedMission;
+    const copy = selectedCopy || '';
+    const fragments = [`Mission "${label}" will be branded onto this device.`];
+    if (copy) {
+      fragments.push(copy);
+    }
+    summaryEl.textContent = fragments.join(' ');
+  }
+
+  function focusCurrentStep() {
+    const currentStage = dialog.querySelector(`[data-ritual-step="${activeStep}"]`);
+    if (!currentStage) return;
+    const target = currentStage.querySelector(
+      'button:not([disabled]), [href]:not([tabindex="-1"])',
+    );
+    if (target) {
+      target.focus({ preventScroll: true });
+    } else {
+      dialog.focus({ preventScroll: true });
+    }
+  }
+
+  function openRitual(initialStep = 'mission') {
+    if (ritualComplete) return;
+    const alreadyOpen = Boolean(dialog.open);
+    try {
+      dialog.removeAttribute('hidden');
+    } catch {}
+    setStep(initialStep);
+    if (!alreadyOpen) {
+      if (typeof dialog.showModal === 'function') {
+        try {
+          dialog.showModal();
+        } catch (error) {
+          console.warn('[landing] failed to open mission dialog via showModal', error);
+          dialog.setAttribute('open', '');
+        }
+      } else {
+        dialog.setAttribute('open', '');
+      }
+      dialog.classList.add('landing-ritual--open');
+      dialog.setAttribute('aria-hidden', 'false');
+      if (focusTrapDisposer) {
+        focusTrapDisposer();
+      }
+      focusTrapDisposer = trapFocusWithin(dialog);
+      dialog.addEventListener('cancel', handleCancel);
+      dialog.addEventListener('close', handleClose);
+    } else {
+      dialog.setAttribute('aria-hidden', 'false');
+      focusCurrentStep();
+    }
+  }
+
+  function closeRitual() {
+    ritualComplete = true;
+    dialog.removeEventListener('cancel', handleCancel);
+    dialog.removeEventListener('close', handleClose);
+    if (focusTrapDisposer) {
+      focusTrapDisposer();
+      focusTrapDisposer = null;
+    }
+    try {
+      if (typeof dialog.close === 'function') {
+        dialog.close();
+      } else {
+        dialog.removeAttribute('open');
+      }
+    } catch (error) {
+      dialog.removeAttribute('open');
+    }
+    dialog.classList.remove('landing-ritual--open');
+    dialog.setAttribute('aria-hidden', 'true');
+    enterLink.focus({ preventScroll: true });
+  }
+
+  function lockCTA() {
+    enterLink.classList.add(CTA_LOCKED_CLASS);
+    enterLink.setAttribute('aria-disabled', 'true');
+    enterLink.setAttribute('tabindex', '-1');
+    enterLink.dataset.missionLocked = 'true';
+    enterLink.addEventListener('click', blockLinkActivation, true);
+  }
+
+  function unlockCTA(profile) {
+    enterLink.classList.remove(CTA_LOCKED_CLASS);
+    enterLink.removeAttribute('aria-disabled');
+    enterLink.removeAttribute('tabindex');
+    delete enterLink.dataset.missionLocked;
+    enterLink.removeEventListener('click', blockLinkActivation, true);
+    if (profile) {
+      try {
+        document.dispatchEvent(
+          new CustomEvent('landing:mission-set', {
+            detail: profile,
+          }),
+        );
+      } catch (error) {
+        console.warn('[landing] failed to dispatch mission event', error);
+      }
+    }
+  }
+
+  missionButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      selectedMission = button.dataset.missionOption || '';
+      selectedLabel = button.dataset.missionLabel || selectedMission;
+      selectedCopy = button.dataset.missionCopy || '';
+      setStep('consent');
+    });
+  });
+
+  backButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      if (activeStep === 'confirm') {
+        setStep('consent');
+      } else {
+        setStep('mission');
+      }
+    });
+  });
+
+  if (consentButton) {
+    consentButton.addEventListener('click', () => {
+      if (!selectedMission) {
+        setStep('mission');
+        return;
+      }
+      formatSummary();
+      setStep('confirm');
+    });
+  }
+
+  if (confirmButton) {
+    confirmButton.addEventListener('click', () => {
+      if (!selectedMission) {
+        setStep('mission');
+        return;
+      }
+      const timestamp = Date.now();
+      const profile = {
+        mission: selectedMission,
+        label: selectedLabel || selectedMission,
+        copy: selectedCopy || '',
+        timestamp,
+      };
+      persistMissionProfile(profile);
+      unlockCTA(profile);
+      closeRitual();
+      dispatchWhisperEvent('mission_confirm', { minIntensity: 1 });
+    });
+  }
+
+  const storedProfile = loadMissionProfile();
+  if (storedProfile) {
+    ritualComplete = true;
+    unlockCTA(storedProfile);
+    return storedProfile;
+  }
+
+  lockCTA();
+  // Wait a frame to avoid blocking initial rendering.
+  scheduleFrame(() => {
+    openRitual();
+  });
+
+  return null;
+}
 
 function applySavedTheme() {
   if (typeof document === 'undefined') return 'fem';
@@ -132,6 +445,7 @@ export async function initLandingPage({ shell }) {
   motionMode = applyMotionPreference(motionMode);
 
   setupThemeToggles();
+  setupMissionRitual();
 
   function revealAudioPanel() {
     if (!shell?.audioPanel) return;

--- a/modules/tts-dispatcher.js
+++ b/modules/tts-dispatcher.js
@@ -19,6 +19,7 @@ const EVENT_COOLDOWNS = {
   stack_overflow: 6200,
   tag_add: 2600,
   tag_clear: 4200,
+  mission_confirm: 7200,
 };
 
 let eventCatalog = {};

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -1527,3 +1527,150 @@ animation: pulseGlow 1.8s ease-in-out infinite;
   background-color: rgba(12, 11, 22, 0.8);
   box-shadow: 0 0 24px rgba(102, 243, 255, 0.2);
 }
+
+dialog[data-landing-ritual] {
+  @apply fixed inset-0 z-[2500] m-0 flex w-full items-center justify-center bg-transparent p-0 text-left text-slate-100;
+  max-width: none;
+  border: none;
+}
+
+dialog[data-landing-ritual]::backdrop {
+  @apply bg-night/90 backdrop-blur-[28px];
+  background-image: radial-gradient(circle at 22% 12%, rgba(255, 118, 214, 0.22), transparent 55%),
+    radial-gradient(circle at 78% 85%, rgba(102, 243, 255, 0.25), transparent 60%);
+}
+
+.landing-ritual--open {
+  display: flex;
+}
+
+.landing-ritual__panel {
+  @apply relative mx-auto flex w-full max-w-[min(560px,92vw)] flex-col gap-6 rounded-[2rem] border border-white/12 bg-panel/95 p-8 text-base shadow-[0_28px_80px_rgba(255,118,214,0.28)] backdrop-blur-[32px];
+  @apply fold-cover:max-w-[min(460px,94vw)] fold-cover:p-6 fold-inner:max-w-[620px];
+  @apply transition-all duration-500 ease-kink;
+  box-shadow:
+    0 0 0 1px rgba(102, 243, 255, 0.08),
+    0 32px 68px -28px rgba(102, 243, 255, 0.45);
+}
+
+.landing-ritual__header {
+  @apply flex flex-col gap-2 text-xs uppercase tracking-[0.4em] text-slate-300;
+}
+
+.landing-ritual__eyebrow {
+  @apply text-[0.55rem] font-semibold text-glow/70;
+  letter-spacing: 0.42em;
+}
+
+.landing-ritual__title {
+  @apply text-2xl font-semibold uppercase tracking-[0.45em] text-white;
+  letter-spacing: 0.35em;
+}
+
+.landing-ritual__body {
+  @apply flex flex-col gap-6 text-sm leading-relaxed text-slate-200;
+}
+
+.landing-ritual__stage {
+  @apply flex flex-col gap-6 transition-all duration-500 ease-kink;
+  opacity: 0;
+  transform: translateY(1.25rem);
+  pointer-events: none;
+}
+
+.landing-ritual__stage--active {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.landing-ritual__lead {
+  @apply text-base leading-relaxed text-slate-100;
+}
+
+.landing-ritual__options {
+  @apply grid gap-3;
+}
+
+.landing-ritual__option {
+  @apply group flex w-full flex-col gap-2 rounded-2xl border border-white/10 bg-black/50 px-5 py-4 text-left transition-all duration-300 ease-kink;
+  @apply focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-glow;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.landing-ritual__option:hover {
+  @apply border-glow/70 bg-glow/15;
+  box-shadow:
+    inset 0 0 0 1px rgba(102, 243, 255, 0.3),
+    0 22px 45px -32px rgba(102, 243, 255, 0.55);
+}
+
+.landing-ritual__option-title {
+  @apply text-sm font-semibold uppercase tracking-[0.4em] text-white;
+}
+
+.landing-ritual__option-copy {
+  @apply text-xs uppercase tracking-[0.3em] text-slate-300;
+}
+
+.landing-ritual__bullet-list {
+  @apply space-y-2 text-xs uppercase tracking-[0.35em] text-slate-300;
+  list-style: none;
+}
+
+.landing-ritual__bullet-list li::before {
+  content: '•';
+  @apply pr-2 text-glow;
+}
+
+.landing-ritual__actions {
+  @apply flex flex-col gap-3 sm:flex-row sm:justify-between;
+}
+
+.landing-ritual__primary {
+  @apply inline-flex items-center justify-center gap-2 rounded-full border border-transparent bg-gradient-to-r from-glow to-blush px-6 py-3 text-xs font-semibold uppercase tracking-[0.4em] text-night transition-all duration-300 ease-kink;
+  box-shadow:
+    0 0 18px rgba(102, 243, 255, 0.35),
+    0 0 36px rgba(255, 118, 214, 0.28);
+}
+
+.landing-ritual__primary:hover {
+  filter: brightness(1.05);
+  box-shadow:
+    0 0 22px rgba(102, 243, 255, 0.45),
+    0 0 42px rgba(255, 118, 214, 0.35);
+}
+
+.landing-ritual__secondary {
+  @apply inline-flex items-center justify-center gap-2 rounded-full border border-white/18 bg-black/40 px-6 py-3 text-xs font-semibold uppercase tracking-[0.4em] text-slate-200 transition-all duration-300 ease-kink;
+}
+
+.landing-ritual__secondary:hover {
+  @apply border-white/30 bg-white/15 text-white;
+}
+
+.landing-ritual__disclosure {
+  @apply text-[0.6rem] uppercase tracking-[0.35em] text-slate-400;
+}
+
+.landing-enter--locked {
+  @apply cursor-not-allowed opacity-60;
+  pointer-events: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  dialog[data-landing-ritual]::backdrop {
+    @apply backdrop-blur-none;
+  }
+  .landing-ritual__panel {
+    @apply transition-none;
+    box-shadow: 0 0 0 1px rgba(102, 243, 255, 0.28);
+  }
+  .landing-ritual__stage {
+    @apply transition-none;
+    transform: none;
+  }
+  .landing-ritual__stage--active {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a three-step mission consent ritual dialog to the landing page and gate the gallery CTA until it completes
- persist the chosen mission profile to localStorage, broadcast a landing:mission-set event, and trigger the new mission_confirm whisper
- extend Tailwind components, TTS lines, and docs to cover the ritual styling, new audio copy, and reset guidance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea070916f0832cbbd9c3759d7bad1b