### PR TITLE
Add interactive shame dossier overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ A modern, visually unified web app for exploring, filtering, and discovering art
 - **Responsive Design**: Works on desktop and mobile, with adaptive layouts and touch-friendly controls.
 - **Fun Interactions**: Includes taunt banners, shame badges, and playful iconography.
 
+## Shame Dossier
+
+- Open the dossier from the **DOSSIER** controls in the command bar (inner layout) or the cover toolbar to review a glassmorphic timeline of every tag edit, gallery crawl milestone, favorite toggle, and taunt.
+- Use the **Wipe log** action inside the overlay (or clear `localStorage['te.dossier.entries']` in the console) to purge local history instantly.
+- Dossier whispers respect the TTS intensity slider: higher intensities surface harsher `dossier_open` / `dossier_revisit` lines, while disabled TTS falls back to a soft on-screen caption inside the panel.
+
 ## Project Structure
 
 - `index.html` – Main entry point with inline Tailwind Play config and component layers (no build step required)

--- a/data/tts_lines.json
+++ b/data/tts_lines.json
@@ -88,5 +88,35 @@
       "Tried to escape. Came crawling back. I knew you would.",
       "Door swings shut behind you. You're staying."
     ]
+  ],
+  "dossier_open": [
+    [],
+    [
+      "Opening the dossier? Hope you're ready to read the receipts.",
+      "Cracking the dossier whisper-quiet, like anyone isn't watching."
+    ],
+    [
+      "Every tag, every favorite—it's all in ink now.",
+      "You asked for the dossier, so stare at the mess you made."
+    ],
+    [
+      "Unsealing your dossier. Take a breath before it devours you.",
+      "Flip through every crime slowly. I'll narrate the fall."
+    ]
+  ],
+  "dossier_revisit": [
+    [],
+    [
+      "Back to your dossier already? You love the sting.",
+      "Peeking again? Still sure you can handle the truth?"
+    ],
+    [
+      "Couldn't resist revisiting the evidence, huh?",
+      "You keep re-reading the same confessions. Masochist."
+    ],
+    [
+      "Running your fingers over every slip again. Delicious.",
+      "You live here now—inside the dossier, inside the shame."
+    ]
   ]
 }

--- a/modules/components/command-bar.js
+++ b/modules/components/command-bar.js
@@ -13,6 +13,16 @@ template.innerHTML = `
           <button class="control-btn command-btn audio-toggle" type="button">AUDIO</button>
           <button class="control-btn command-btn theme-toggle" type="button">GLOW</button>
           <button
+            id="dossier-btn"
+            class="control-btn command-btn dossier-toggle"
+            type="button"
+            aria-haspopup="dialog"
+            aria-controls="shame-dossier-overlay"
+            aria-label="Open shame dossier overlay"
+          >
+            DOSSIER
+          </button>
+          <button
             id="filters-btn"
             class="control-btn command-btn"
             type="button"
@@ -57,6 +67,17 @@ template.innerHTML = `
           <span aria-hidden="true">⌂</span>
           <span class="cover-command-label">Home</span>
         </a>
+        <button
+          id="cover-dossier-btn"
+          class="cover-command-btn dossier-toggle"
+          type="button"
+          aria-haspopup="dialog"
+          aria-controls="shame-dossier-overlay"
+          aria-label="Open shame dossier overlay"
+        >
+          <span aria-hidden="true">🗒</span>
+          <span class="cover-command-label">Dossier</span>
+        </button>
         <button
           id="cover-filters-btn"
           class="cover-command-btn"

--- a/modules/favorites.js
+++ b/modules/favorites.js
@@ -49,7 +49,7 @@ export function addFavorite(artistName) {
   
   if (wasAdded) {
     saveFavorites();
-    dispatchFavoritesChanged();
+    dispatchFavoritesChanged('added', artistName);
   }
   
   return wasAdded;
@@ -66,7 +66,7 @@ export function removeFavorite(artistName) {
   
   if (wasRemoved) {
     saveFavorites();
-    dispatchFavoritesChanged();
+    dispatchFavoritesChanged('removed', artistName);
   }
   
   return wasRemoved;
@@ -117,7 +117,7 @@ export function clearAllFavorites() {
   const count = favoriteArtists.size;
   favoriteArtists.clear();
   saveFavorites();
-  dispatchFavoritesChanged();
+  dispatchFavoritesChanged('cleared');
   return count;
 }
 
@@ -137,7 +137,7 @@ export function importFavorites(jsonString) {
     if (Array.isArray(parsed)) {
       favoriteArtists = new Set(parsed);
       saveFavorites();
-      dispatchFavoritesChanged();
+      dispatchFavoritesChanged('imported');
       return true;
     }
   } catch (error) {
@@ -149,14 +149,24 @@ export function importFavorites(jsonString) {
 /**
  * Dispatch event when favorites change
  */
-function dispatchFavoritesChanged() {
-  const event = new CustomEvent('favorites:changed', {
-    detail: {
-      count: favoriteArtists.size,
-      favorites: Array.from(favoriteArtists)
-    }
+function dispatchFavoritesChanged(action = 'updated', artistName = '') {
+  const detail = {
+    action,
+    artist: artistName || undefined,
+    subject: artistName || undefined,
+    count: favoriteArtists.size,
+    favorites: Array.from(favoriteArtists),
+    dedupeKey: `${action}:${artistName}:${favoriteArtists.size}`,
+  };
+  const legacyEvent = new CustomEvent('favorites:changed', {
+    detail,
   });
-  document.dispatchEvent(event);
+  document.dispatchEvent(legacyEvent);
+  try {
+    document.dispatchEvent(new CustomEvent('favorites:change', { detail }));
+  } catch (error) {
+    console.warn('Failed to dispatch favorites:change dossier event', error);
+  }
 }
 
 /**

--- a/modules/humiliation.js
+++ b/modules/humiliation.js
@@ -3,6 +3,34 @@
 import { showToast, getCopiedCount } from "./sidebar.js";
 import { getActiveTags } from "./tags.js";
 
+const TAUNT_DEDUPE_MS = 4200;
+let lastTauntDetail = { message: "", at: 0 };
+
+function dispatchTauntEvent(message, detail = {}) {
+  if (typeof document === "undefined" || !message) return;
+  const now = Date.now();
+  if (lastTauntDetail.message === message && now - lastTauntDetail.at < TAUNT_DEDUPE_MS) {
+    return;
+  }
+  lastTauntDetail = { message, at: now };
+  const payload = {
+    message,
+    context: detail,
+    dedupeKey: `taunt:${message}`,
+  };
+  try {
+    document.dispatchEvent(new CustomEvent("humiliation:taunt", { detail: payload }));
+  } catch (error) {
+    try {
+      const evt = document.createEvent("CustomEvent");
+      evt.initCustomEvent("humiliation:taunt", false, false, payload);
+      document.dispatchEvent(evt);
+    } catch (fallbackError) {
+      console.warn("[humiliation] Failed to dispatch taunt event", fallbackError || error);
+    }
+  }
+}
+
 let tauntPool = [];
 let timer = null;
 
@@ -22,7 +50,10 @@ function startTauntTicker(taunts = [], intervalMs = 30000) {
     }
     const pool = tauntPool.concat(dynamic);
     const msg = pool[Math.floor(Math.random() * pool.length)];
-    if (msg) showToast(msg);
+    if (msg) {
+      showToast(msg);
+      dispatchTauntEvent(msg, { activeTags: active.size, copies });
+    }
   }, intervalMs);
 }
 

--- a/modules/pages/gallery.js
+++ b/modules/pages/gallery.js
@@ -59,6 +59,11 @@ import {
 } from '../tag-explorer.js';
 import { showAzureVoiceSelector } from '../azure-tts.js';
 import { configureWhisperCatalog, dispatchWhisperEvent } from '../tts-dispatcher.js';
+import {
+  initShameDossier,
+  openShameDossier,
+  getDossierEntries,
+} from '../shame-dossier.js';
 
 const MOTION_STORAGE_KEY = 'te.motion.preference';
 const MOTION_DEFAULT = 'full';
@@ -172,7 +177,7 @@ function setupTagSearchModeSelector() {
 async function setupFavoritesButton() {
   await customElements.whenDefined('te-command-bar');
   await new Promise(resolve => setTimeout(resolve, 0));
-  
+
   const favoritesBtn = document.getElementById('favorites-btn');
   const favoritesCount = document.getElementById('favorites-count');
   if (!favoritesBtn) return;
@@ -376,6 +381,62 @@ function setupMuteToggle() {
   document.addEventListener('audio:mutechange', (event) => {
     if (!event?.detail || typeof event.detail.muted === 'undefined') return;
     updateButtonState(Boolean(event.detail.muted));
+  });
+}
+
+async function setupDossierButton() {
+  await customElements.whenDefined('te-command-bar');
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const entries = [
+    { el: document.getElementById('dossier-btn'), source: 'inner' },
+    { el: document.getElementById('cover-dossier-btn'), source: 'cover' },
+  ].filter(({ el }) => el instanceof HTMLElement);
+
+  if (!entries.length) {
+    initShameDossier();
+    return;
+  }
+
+  const setExpanded = (isOpen) => {
+    entries.forEach(({ el }) => {
+      if (!el) return;
+      el.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+      el.classList.toggle('is-active', Boolean(isOpen));
+    });
+  };
+
+  const setHasEntries = (hasEntries) => {
+    entries.forEach(({ el }) => {
+      if (!el) return;
+      if (hasEntries) {
+        el.dataset.hasEntries = 'true';
+      } else {
+        delete el.dataset.hasEntries;
+      }
+    });
+  };
+
+  setHasEntries(false);
+  setExpanded(false);
+
+  entries.forEach(({ el, source }) => {
+    el.addEventListener('click', () => {
+      openShameDossier({ source });
+    });
+  });
+
+  document.addEventListener('dossier:toggle', (event) => {
+    setExpanded(Boolean(event?.detail?.open));
+  });
+
+  document.addEventListener('dossier:append', () => setHasEntries(true));
+  document.addEventListener('dossier:cleared', () => setHasEntries(false));
+
+  initShameDossier().then(() => {
+    const hasAny = (getDossierEntries() || []).length > 0;
+    setHasEntries(hasAny);
+    setExpanded(false);
   });
 }
 
@@ -628,6 +689,7 @@ export async function initGalleryPage({ foldAdapter } = {}) {
 
   // Don't call setRandomBackground() here - let the controller handle it after initialization
 
+  await initShameDossier();
   await initTags();
   initGallery();
 
@@ -701,6 +763,7 @@ export async function initGalleryPage({ foldAdapter } = {}) {
   setupFiltersButton();
   setupForceFetch();
   setupFavoritesButton();
+  setupDossierButton();
 
   const idleCleanup = setupIdleWhispers();
 

--- a/modules/shame-dossier.js
+++ b/modules/shame-dossier.js
@@ -1,0 +1,659 @@
+const STORAGE_KEY = 'te.dossier.entries';
+const MAX_ENTRIES = 240;
+const DEDUPE_WINDOW_MS = 4200;
+
+let entries = [];
+let initPromise = null;
+let dossierElement = null;
+let hasOpened = false;
+const dedupeMap = new Map();
+const listeners = new Map();
+
+function now() {
+  return Date.now();
+}
+
+function safeParse(json) {
+  try {
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+function loadEntriesFromStorage() {
+  if (entries.length) return entries;
+  if (typeof window === 'undefined') {
+    entries = [];
+    return entries;
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      entries = [];
+      return entries;
+    }
+    const parsed = safeParse(raw);
+    if (Array.isArray(parsed)) {
+      entries = parsed
+        .map((item) => {
+          const ts = Number(item?.timestamp) || now();
+          return {
+            id: item?.id || `${ts}-${Math.random().toString(16).slice(2)}`,
+            timestamp: ts,
+            title: String(item?.title || 'Recorded action'),
+            detail: String(item?.detail || ''),
+            type: String(item?.type || 'system'),
+            category: String(item?.category || 'system'),
+            accent: String(item?.accent || ''),
+            meta: item?.meta || {},
+          };
+        })
+        .sort((a, b) => b.timestamp - a.timestamp)
+        .slice(0, MAX_ENTRIES);
+      return entries;
+    }
+  } catch (error) {
+    console.warn('[shame-dossier] Failed to parse storage entries', error);
+  }
+  entries = [];
+  return entries;
+}
+
+function persistEntries() {
+  if (typeof window === 'undefined') return;
+  try {
+    const payload = entries.slice(0, MAX_ENTRIES).map((entry) => ({
+      id: entry.id,
+      timestamp: entry.timestamp,
+      title: entry.title,
+      detail: entry.detail,
+      type: entry.type,
+      category: entry.category,
+      accent: entry.accent,
+      meta: entry.meta || {},
+    }));
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    console.warn('[shame-dossier] Failed to persist entries', error);
+  }
+}
+
+function ensureElement() {
+  if (typeof document === 'undefined') return null;
+  if (dossierElement && document.body.contains(dossierElement)) {
+    return dossierElement;
+  }
+  dossierElement = document.querySelector('te-shame-dossier');
+  if (!dossierElement) {
+    dossierElement = document.createElement('te-shame-dossier');
+    dossierElement.id = 'shame-dossier-overlay';
+    dossierElement.setAttribute('hidden', '');
+    document.body.appendChild(dossierElement);
+  }
+  if (typeof dossierElement.setEntries === 'function') {
+    dossierElement.setEntries(entries);
+  }
+  return dossierElement;
+}
+
+function registerCustomElement() {
+  if (typeof customElements === 'undefined') return;
+  if (customElements.get('te-shame-dossier')) return;
+  const template = document.createElement('template');
+  template.innerHTML = `
+    <div class="shame-dossier-overlay" data-open="false">
+      <div class="shame-dossier-backdrop" data-close="true"></div>
+      <section
+        class="shame-dossier-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="shame-dossier-title"
+      >
+        <header class="shame-dossier-header">
+          <div class="shame-dossier-heading">
+            <h2 id="shame-dossier-title">Shame dossier</h2>
+            <p class="shame-dossier-caption">Every indulgence you tried to hide.</p>
+            <p class="shame-dossier-whisper" data-soft-whisper aria-live="polite"></p>
+          </div>
+          <div class="shame-dossier-actions">
+            <label class="shame-dossier-filter">
+              <span class="sr-only">Filter dossier</span>
+              <select data-filter>
+                <option value="all">Everything</option>
+                <option value="tag">Tags</option>
+                <option value="favorites">Favorites</option>
+                <option value="progress">Progress</option>
+                <option value="taunt">Taunts</option>
+                <option value="system">System</option>
+              </select>
+            </label>
+            <button type="button" class="shame-dossier-clear" data-clear>
+              Wipe log
+            </button>
+            <button type="button" class="shame-dossier-close" data-close>
+              <span aria-hidden="true">✕</span>
+              <span class="sr-only">Close dossier</span>
+            </button>
+          </div>
+        </header>
+        <div class="shame-dossier-content">
+          <ol class="shame-dossier-timeline" data-list role="list"></ol>
+          <div class="shame-dossier-empty" data-empty hidden>
+            <p>No shame logged yet. Curious.</p>
+          </div>
+        </div>
+        <div class="sr-only" aria-live="polite" data-live></div>
+      </section>
+    </div>
+  `;
+
+  class ShameDossierElement extends HTMLElement {
+    constructor() {
+      super();
+      this._entries = [];
+      this._filter = 'all';
+      this._rendered = false;
+      this._handleKeydown = this._handleKeydown.bind(this);
+    }
+
+    connectedCallback() {
+      if (this._rendered) return;
+      this._rendered = true;
+      const content = template.content.cloneNode(true);
+      this.appendChild(content);
+      this.overlay = this.querySelector('.shame-dossier-overlay');
+      this.list = this.querySelector('[data-list]');
+      this.emptyState = this.querySelector('[data-empty]');
+      this.filterSelect = this.querySelector('[data-filter]');
+      this.clearButton = this.querySelector('[data-clear]');
+      this.closeButtons = this.querySelectorAll('[data-close]');
+      this.softWhisper = this.querySelector('[data-soft-whisper]');
+      this.liveRegion = this.querySelector('[data-live]');
+      this.panel = this.querySelector('.shame-dossier-panel');
+
+      if (this.filterSelect) {
+        this.filterSelect.addEventListener('change', () => {
+          this._filter = this.filterSelect.value;
+          this.render();
+        });
+      }
+
+      if (this.clearButton) {
+        this.clearButton.addEventListener('click', () => {
+          clearDossierEntries();
+          this.focus();
+        });
+      }
+
+      this.closeButtons.forEach((btn) => {
+        btn.addEventListener('click', () => this.close());
+      });
+
+      this.addEventListener('click', (event) => {
+        if (event.target?.dataset?.close === 'true') {
+          this.close();
+        }
+      });
+
+      this.setEntries(entries);
+    }
+
+    disconnectedCallback() {
+      document.removeEventListener('keydown', this._handleKeydown);
+    }
+
+    _handleKeydown(event) {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        this.close();
+      }
+    }
+
+    setEntries(list) {
+      this._entries = Array.isArray(list) ? list.slice() : [];
+      this.render();
+    }
+
+    setSoftWhisper(text) {
+      if (!this.softWhisper) return;
+      if (!text) {
+        this.softWhisper.textContent = '';
+        this.softWhisper.hidden = true;
+        return;
+      }
+      this.softWhisper.textContent = text;
+      this.softWhisper.hidden = false;
+    }
+
+    render() {
+      if (!this.list) return;
+      const filter = this._filter || 'all';
+      const filtered = this._entries.filter((entry) => {
+        if (filter === 'all') return true;
+        return entry.category === filter;
+      });
+      this.list.innerHTML = '';
+      if (!filtered.length) {
+        if (this.emptyState) this.emptyState.hidden = false;
+        return;
+      }
+      if (this.emptyState) this.emptyState.hidden = true;
+      const fragment = document.createDocumentFragment();
+      filtered
+        .sort((a, b) => b.timestamp - a.timestamp)
+        .forEach((entry) => {
+          const item = document.createElement('li');
+          item.className = `shame-dossier-entry ${entry.accent ? `is-${entry.accent}` : ''}`;
+          item.dataset.type = entry.type;
+          item.dataset.category = entry.category;
+
+          const marker = document.createElement('div');
+          marker.className = 'shame-dossier-entry__marker';
+          marker.setAttribute('aria-hidden', 'true');
+
+          const body = document.createElement('article');
+          body.className = 'shame-dossier-entry__body';
+          body.innerHTML = `
+            <header>
+              <h3>${entry.title}</h3>
+              <time datetime="${new Date(entry.timestamp).toISOString()}">
+                ${new Intl.DateTimeFormat(undefined, {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                  hour12: false,
+                }).format(entry.timestamp)}
+              </time>
+            </header>
+            <p>${entry.detail}</p>
+          `;
+          if (entry.meta && typeof entry.meta === 'object') {
+            const metaList = Object.entries(entry.meta)
+              .filter(([key, value]) =>
+                typeof value !== 'undefined' && value !== null && value !== '',
+              )
+              .map(
+                ([key, value]) =>
+                  `<span class="shame-dossier-meta" data-key="${key}">${key}: <strong>${value}</strong></span>`,
+              )
+              .join('');
+            if (metaList) {
+              const footer = document.createElement('footer');
+              footer.className = 'shame-dossier-entry__meta';
+              footer.innerHTML = metaList;
+              body.appendChild(footer);
+            }
+          }
+
+          item.appendChild(marker);
+          item.appendChild(body);
+          fragment.appendChild(item);
+        });
+      this.list.appendChild(fragment);
+    }
+
+    open() {
+      if (!this.overlay) return;
+      this.removeAttribute('hidden');
+      this.overlay.dataset.open = 'true';
+      document.body.classList.add('shame-dossier-open');
+      if (this.panel) {
+        this.panel.setAttribute('tabindex', '-1');
+        this.panel.focus({ preventScroll: true });
+      }
+      document.addEventListener('keydown', this._handleKeydown);
+      try {
+        document.dispatchEvent(new CustomEvent('dossier:toggle', { detail: { open: true } }));
+      } catch {}
+    }
+
+    close() {
+      if (!this.overlay) return;
+      this.overlay.dataset.open = 'false';
+      this.setAttribute('hidden', '');
+      document.body.classList.remove('shame-dossier-open');
+      document.removeEventListener('keydown', this._handleKeydown);
+      if (this.panel) {
+        this.panel.removeAttribute('tabindex');
+      }
+      this.setSoftWhisper('');
+      try {
+        document.dispatchEvent(new CustomEvent('dossier:toggle', { detail: { open: false } }));
+      } catch {}
+    }
+
+    announce(message) {
+      if (!this.liveRegion) return;
+      this.liveRegion.textContent = '';
+      if (message) {
+        requestAnimationFrame(() => {
+          this.liveRegion.textContent = message;
+        });
+      }
+    }
+  }
+
+  customElements.define('te-shame-dossier', ShameDossierElement);
+}
+
+function normalizeEntryPayload(type, detail = {}) {
+  const timestamp = now();
+  const entry = {
+    id: `${type}-${timestamp}-${Math.random().toString(16).slice(2)}`,
+    timestamp,
+    type,
+    category: 'system',
+    title: 'Logged action',
+    detail: '',
+    accent: '',
+    meta: {},
+    dedupeKey: detail?.dedupeKey,
+  };
+
+  switch (type) {
+    case 'tags:add': {
+      const tag = String(detail?.tag || '').replaceAll('_', ' ');
+      const total = Number(detail?.totalActive) || 0;
+      entry.category = 'tag';
+      entry.title = `Tag added: ${tag || 'unknown'}`;
+      entry.detail = total
+        ? `Stack now at ${total} active ${total === 1 ? 'tag' : 'tags'}.`
+        : 'Tag toggled on.';
+      entry.meta = {
+        tag: detail?.tag || tag,
+        stack: total,
+      };
+      entry.accent = 'cyan';
+      entry.dedupeKey = entry.dedupeKey || `tag-add:${detail?.tag}:${total}`;
+      break;
+    }
+    case 'tags:remove': {
+      const tag = String(detail?.tag || '').replaceAll('_', ' ');
+      const total = Number(detail?.totalActive) || 0;
+      entry.category = 'tag';
+      entry.title = `Tag removed: ${tag || 'unknown'}`;
+      entry.detail = total
+        ? `Stack trimmed to ${total} ${total === 1 ? 'tag' : 'tags'}.`
+        : 'No tags remain.';
+      entry.meta = {
+        tag: detail?.tag || tag,
+        stack: total,
+      };
+      entry.accent = 'cyan';
+      entry.dedupeKey = entry.dedupeKey || `tag-remove:${detail?.tag}:${total}`;
+      break;
+    }
+    case 'tags:clear': {
+      entry.category = 'tag';
+      entry.title = 'Tag stack wiped';
+      entry.detail = 'All filters cleared. Pretending innocence?';
+      entry.accent = 'pink';
+      entry.meta = { previous: Number(detail?.previousCount) || 0 };
+      entry.dedupeKey = entry.dedupeKey || `tag-clear:${detail?.previousCount}`;
+      break;
+    }
+    case 'favorites:change': {
+      const action = String(detail?.action || 'updated');
+      const artist = String(detail?.artist || detail?.subject || '').trim();
+      entry.category = 'favorites';
+      if (action === 'added') {
+        entry.title = artist ? `Favorited ${artist}` : 'Artist favorited';
+        entry.detail = 'Pinned for repeat inspection.';
+        entry.accent = 'pink';
+      } else if (action === 'removed') {
+        entry.title = artist ? `Unfavorited ${artist}` : 'Artist unpinned';
+        entry.detail = 'Scrubbing the wall never hides the obsession.';
+        entry.accent = 'slate';
+      } else if (action === 'cleared') {
+        entry.title = 'Favorites wiped';
+        entry.detail = 'An empty trophy case still smells like you.';
+        entry.accent = 'slate';
+      } else if (action === 'imported') {
+        entry.title = 'Favorites imported';
+        entry.detail = 'Smuggled trophies restored.';
+        entry.accent = 'pink';
+      } else {
+        entry.title = 'Favorites updated';
+        entry.detail = 'Another shuffle of the shrine.';
+        entry.accent = 'slate';
+      }
+      entry.meta = {
+        count: Number(detail?.count) || 0,
+        artist,
+      };
+      entry.dedupeKey = entry.dedupeKey || `favorites:${action}:${artist}:${detail?.count}`;
+      break;
+    }
+    case 'goal:progress': {
+      const shown = Number(detail?.shown) || 0;
+      const total = Number(detail?.total) || 0;
+      entry.category = 'progress';
+      entry.title = 'Gallery progress logged';
+      entry.detail = total
+        ? `You've exposed yourself to ${shown}/${total} profiles.`
+        : `You're ${shown} entries deep.`;
+      entry.meta = {
+        direction: detail?.direction || 'forward',
+        page: detail?.page,
+      };
+      entry.accent = 'violet';
+      entry.dedupeKey = entry.dedupeKey || `progress:${detail?.signature}`;
+      break;
+    }
+    case 'humiliation:taunt': {
+      const message = String(detail?.message || '').trim();
+      entry.category = 'taunt';
+      entry.title = 'Taunt delivered';
+      entry.detail = message || 'A fresh whisper curled around you.';
+      entry.accent = 'red';
+      entry.meta = {
+        context: detail?.context || '',
+      };
+      entry.dedupeKey = entry.dedupeKey || `taunt:${message}`;
+      break;
+    }
+    case 'dossier:open': {
+      entry.category = 'system';
+      entry.title = detail?.first ? 'First dossier inspection' : 'Dossier revisited';
+      entry.detail = detail?.first
+        ? 'Every entry is timestamped. Nothing slips away.'
+        : "You knew you couldn't look away for long.";
+      entry.accent = 'teal';
+      entry.meta = { source: detail?.source || 'unknown' };
+      entry.dedupeKey = entry.dedupeKey || `open:${detail?.first}`;
+      break;
+    }
+    default: {
+      if (detail?.entry) {
+        return {
+          ...entry,
+          ...detail.entry,
+          timestamp,
+        };
+      }
+      entry.detail = detail?.detail || 'Action recorded.';
+      entry.meta = detail?.meta || {};
+      entry.accent = detail?.accent || 'slate';
+    }
+  }
+  return entry;
+}
+
+function shouldDedupe(entry) {
+  if (!entry || !entry.dedupeKey) return false;
+  const key = String(entry.dedupeKey);
+  const previous = dedupeMap.get(key) || 0;
+  const current = entry.timestamp;
+  if (current - previous < DEDUPE_WINDOW_MS) {
+    return true;
+  }
+  dedupeMap.set(key, current);
+  return false;
+}
+
+function appendEntry(entry) {
+  if (!entry || shouldDedupe(entry)) return null;
+  entries = [entry, ...entries].slice(0, MAX_ENTRIES);
+  persistEntries();
+  const element = ensureElement();
+  if (element && typeof element.setEntries === 'function') {
+    element.setEntries(entries);
+    if (element.overlay?.dataset?.open === 'true') {
+      element.announce(`${entry.title}. ${entry.detail}`);
+    }
+  }
+  if (typeof document !== 'undefined') {
+    try {
+      document.dispatchEvent(
+        new CustomEvent('dossier:append', {
+          detail: { entry },
+        }),
+      );
+    } catch (error) {
+      console.warn('[shame-dossier] Failed to broadcast append event', error);
+    }
+  }
+  return entry;
+}
+
+function logDossierEvent(type, detail = {}) {
+  const entry = normalizeEntryPayload(type, detail);
+  if (!entry) return null;
+  return appendEntry(entry);
+}
+
+function clearDossierEntries() {
+  entries = [];
+  persistEntries();
+  const element = ensureElement();
+  if (element && typeof element.setEntries === 'function') {
+    element.setEntries(entries);
+    element.announce('Dossier log cleared.');
+  }
+  if (typeof document !== 'undefined') {
+    try {
+      document.dispatchEvent(new CustomEvent('dossier:cleared'));
+    } catch {}
+  }
+}
+
+function getDossierEntries(filter) {
+  if (!filter || filter === 'all') {
+    return entries.slice();
+  }
+  if (typeof filter === 'string') {
+    return entries.filter((entry) => entry.category === filter || entry.type === filter);
+  }
+  if (typeof filter === 'function') {
+    return entries.filter(filter);
+  }
+  return entries.slice();
+}
+
+function bindEventListener(eventName, handler) {
+  if (typeof document === 'undefined') return;
+  const key = String(eventName);
+  if (!key || typeof handler !== 'function') return;
+  if (listeners.has(key)) return;
+  const wrapped = (event) => {
+    try {
+      handler(event?.detail || {}, event);
+    } catch (error) {
+      console.warn(`[shame-dossier] Handler for ${key} failed`, error);
+    }
+  };
+  listeners.set(key, wrapped);
+  document.addEventListener(key, wrapped);
+}
+
+function ensureListeners() {
+  bindEventListener('tags:add', (detail) => logDossierEvent('tags:add', detail));
+  bindEventListener('tags:remove', (detail) => logDossierEvent('tags:remove', detail));
+  bindEventListener('tags:clear', (detail) => logDossierEvent('tags:clear', detail));
+  bindEventListener('favorites:change', (detail) => logDossierEvent('favorites:change', detail));
+  bindEventListener('goal:progress', (detail) => logDossierEvent('goal:progress', detail));
+  bindEventListener('humiliation:taunt', (detail) => logDossierEvent('humiliation:taunt', detail));
+  bindEventListener('dossier:entry', (detail) => {
+    if (detail?.type) {
+      logDossierEvent(detail.type, detail);
+    }
+  });
+}
+
+function initShameDossier() {
+  if (initPromise) return initPromise;
+  initPromise = new Promise((resolve) => {
+    if (typeof document === 'undefined') {
+      resolve(null);
+      return;
+    }
+    requestAnimationFrame(() => {
+      registerCustomElement();
+      loadEntriesFromStorage();
+      ensureElement();
+      ensureListeners();
+      if (typeof document !== 'undefined') {
+        try {
+          document.dispatchEvent(new CustomEvent('dossier:ready'));
+        } catch {}
+      }
+      resolve(dossierElement);
+    });
+  });
+  if (typeof window !== 'undefined') {
+    window.te = window.te || {};
+    window.te.dossier = {
+      get entries() {
+        return entries.slice();
+      },
+      open: openShameDossier,
+      clear: clearDossierEntries,
+      filter: getDossierEntries,
+      log: logDossierEvent,
+    };
+  }
+  return initPromise;
+}
+
+function openShameDossier(options = {}) {
+  if (typeof document === 'undefined') return;
+  initShameDossier().then((element) => {
+    const target = element || ensureElement();
+    if (!target || typeof target.open !== 'function') return;
+    target.open();
+    const detail = {
+      source: options?.source || 'unknown',
+      first: !hasOpened,
+    };
+    logDossierEvent('dossier:open', detail);
+    const whisperKey = hasOpened ? 'dossier_revisit' : 'dossier_open';
+    hasOpened = true;
+    import('./tts-dispatcher.js')
+      .then(({ dispatchWhisperEvent }) => {
+        const response = dispatchWhisperEvent(whisperKey, { maxIntensity: 2 });
+        if (response?.reason === 'tts-disabled' && response.text) {
+          target.setSoftWhisper(response.text);
+        } else if (!response?.text) {
+          target.setSoftWhisper('');
+        }
+      })
+      .catch(() => {
+        target.setSoftWhisper('');
+      });
+  });
+}
+
+function closeShameDossier() {
+  if (!dossierElement || typeof dossierElement.close !== 'function') return;
+  dossierElement.close();
+}
+
+export {
+  initShameDossier,
+  openShameDossier,
+  closeShameDossier,
+  logDossierEvent,
+  getDossierEntries,
+  clearDossierEntries,
+};
+

--- a/modules/tags.js
+++ b/modules/tags.js
@@ -85,6 +85,21 @@ const tagIcons = {
 
 let tagSearchMode = "contains"; // "contains", "starts", "ends"
 
+function dispatchTagDossierEvent(name, detail = {}) {
+  if (typeof document === "undefined") return;
+  try {
+    document.dispatchEvent(new CustomEvent(name, { detail }));
+  } catch (error) {
+    try {
+      const evt = document.createEvent("CustomEvent");
+      evt.initCustomEvent(name, false, false, detail);
+      document.dispatchEvent(evt);
+    } catch (fallbackError) {
+      console.warn(`[tags] Failed to dispatch ${name} dossier event`, fallbackError || error);
+    }
+  }
+}
+
 function emitTagUpdate() {
   if (typeof document === "undefined" || typeof document.dispatchEvent !== "function") {
     return;
@@ -251,6 +266,12 @@ function renderTagButtons() {
       button.onclick = () => {
         if (activeTags.has(tag)) {
           activeTags.delete(tag);
+          dispatchTagDossierEvent("tags:remove", {
+            tag,
+            totalActive: activeTags.size,
+            source: "group-button",
+            dedupeKey: `remove:${tag}:${activeTags.size}`,
+          });
         } else {
           activeTags.add(tag);
           spawnBubble(tag);
@@ -258,6 +279,12 @@ function renderTagButtons() {
           if (activeTags.size > 5) {
             dispatchWhisperEvent('stack_overflow', { minIntensity: 2 });
           }
+          dispatchTagDossierEvent("tags:add", {
+            tag,
+            totalActive: activeTags.size,
+            source: "group-button",
+            dedupeKey: `add:${tag}:${activeTags.size}`,
+          });
         }
         button.setAttribute(
           "aria-pressed",
@@ -286,6 +313,12 @@ function renderTagButtons() {
     button.onclick = () => {
       if (activeTags.has(filter)) {
         activeTags.delete(filter);
+        dispatchTagDossierEvent("tags:remove", {
+          tag: filter,
+          totalActive: activeTags.size,
+          source: "search-button",
+          dedupeKey: `remove:${filter}:${activeTags.size}`,
+        });
       } else {
         activeTags.add(filter);
         spawnBubble(filter);
@@ -293,6 +326,12 @@ function renderTagButtons() {
         if (activeTags.size > 5) {
           dispatchWhisperEvent('stack_overflow', { minIntensity: 2 });
         }
+        dispatchTagDossierEvent("tags:add", {
+          tag: filter,
+          totalActive: activeTags.size,
+          source: "search-button",
+          dedupeKey: `add:${filter}:${activeTags.size}`,
+        });
       }
       renderTagButtons();
       if (renderArtists) renderArtists(true);
@@ -308,6 +347,7 @@ function renderTagButtons() {
  */
 function clearAllTags() {
   const hadTags = activeTags.size > 0;
+  const previousCount = activeTags.size;
   activeTags.clear();
   renderTagButtons();
   if (navigator.vibrate) navigator.vibrate(50);
@@ -316,6 +356,11 @@ function clearAllTags() {
   emitTagUpdate();
   if (hadTags) {
     dispatchWhisperEvent('tag_clear', { maxIntensity: 2 });
+    dispatchTagDossierEvent("tags:clear", {
+      previousCount,
+      source: "clear-all",
+      dedupeKey: `clear:${previousCount}`,
+    });
   }
 }
 
@@ -346,6 +391,19 @@ function toggleTag(tag) {
     if (activeTags.size > 5) {
       dispatchWhisperEvent('stack_overflow', { minIntensity: 2 });
     }
+    dispatchTagDossierEvent("tags:add", {
+      tag,
+      totalActive: activeTags.size,
+      source: "toggle",
+      dedupeKey: `add:${tag}:${activeTags.size}`,
+    });
+  } else {
+    dispatchTagDossierEvent("tags:remove", {
+      tag,
+      totalActive: activeTags.size,
+      source: "toggle",
+      dedupeKey: `remove:${tag}:${activeTags.size}`,
+    });
   }
 }
 

--- a/modules/tts-dispatcher.js
+++ b/modules/tts-dispatcher.js
@@ -19,6 +19,8 @@ const EVENT_COOLDOWNS = {
   stack_overflow: 6200,
   tag_add: 2600,
   tag_clear: 4200,
+  dossier_open: 12000,
+  dossier_revisit: 9000,
 };
 
 let eventCatalog = {};

--- a/modules/ui.js
+++ b/modules/ui.js
@@ -48,6 +48,37 @@ function setupInfiniteScroll(options, legacyInfoProvider) {
   let forwardLoading = false;
   let backwardLoading = false;
   const activeSentinels = new Set();
+  let lastProgressSignature = null;
+
+  const emitProgress = (direction) => {
+    if (typeof document === "undefined") return;
+    if (typeof infoProvider !== "function") return;
+    const info = infoProvider();
+    if (!info) return;
+    const signature = `${info.lastRenderedPage}:${info.shown}:${direction}`;
+    if (signature && signature === lastProgressSignature) {
+      return;
+    }
+    lastProgressSignature = signature;
+    const detail = {
+      shown: info.shown,
+      total: info.total,
+      direction,
+      page: info.lastRenderedPage,
+      signature,
+    };
+    try {
+      document.dispatchEvent(new CustomEvent("goal:progress", { detail }));
+    } catch (error) {
+      try {
+        const evt = document.createEvent("CustomEvent");
+        evt.initCustomEvent("goal:progress", false, false, detail);
+        document.dispatchEvent(evt);
+      } catch (fallbackError) {
+        console.warn("[ui] Failed to dispatch goal progress", fallbackError || error);
+      }
+    }
+  };
 
   const requestStep = (direction) => {
     const info = typeof infoProvider === "function" ? infoProvider() : null;
@@ -64,6 +95,7 @@ function setupInfiniteScroll(options, legacyInfoProvider) {
         .catch((error) => {
           console.warn("Infinite scroll backward callback failed", error);
         })
+        .then(() => emitProgress("backward"))
         .finally(() => {
           backwardLoading = false;
         });
@@ -76,6 +108,7 @@ function setupInfiniteScroll(options, legacyInfoProvider) {
         .catch((error) => {
           console.warn("Infinite scroll forward callback failed", error);
         })
+        .then(() => emitProgress("forward"))
         .finally(() => {
           forwardLoading = false;
         });
@@ -119,6 +152,7 @@ function setupInfiniteScroll(options, legacyInfoProvider) {
   };
 
   connectSentinels();
+  requestAnimationFrame(() => emitProgress("init"));
 
   const mutationObserver = new MutationObserver(() => {
     connectSentinels();

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -53,6 +53,9 @@ body {
 width: 100%;
 max-width: 100vw;
 }
+body.shame-dossier-open {
+overflow: hidden;
+}
 body.fem-theme {
 @apply bg-night text-slate-100;
 }
@@ -247,6 +250,301 @@ opacity: 0;
 }
 .command-btn--ghost {
 @apply control-btn bg-white/10 border-white/20 text-slate-200;
+}
+
+.dossier-toggle[data-has-entries='true'] {
+  @apply border-cyan-400/50 bg-cyan-400/10 text-cyan-100;
+  box-shadow: 0 0 24px rgba(102, 243, 255, 0.35);
+}
+
+.shame-dossier-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 240;
+  display: none;
+  align-items: flex-start;
+  justify-content: center;
+  padding: clamp(1rem, 3vw, 3.5rem);
+  background:
+    radial-gradient(circle at 15% 20%, rgba(102, 243, 255, 0.08), transparent 55%),
+    radial-gradient(circle at 85% 80%, rgba(255, 118, 214, 0.08), transparent 55%),
+    rgba(6, 6, 12, 0.65);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.4s cubic-bezier(.4,-0.2,.2,1.2);
+}
+
+.shame-dossier-overlay[data-open="true"] {
+  display: flex;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.shame-dossier-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(5, 5, 12, 0.65);
+  backdrop-filter: blur(34px) saturate(140%);
+}
+
+.shame-dossier-panel {
+  position: relative;
+  width: min(960px, 100%);
+  max-height: min(90vh, 1080px);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  border-radius: 2.5rem;
+  border: 1px solid rgba(102, 243, 255, 0.22);
+  background: linear-gradient(135deg, rgba(20, 22, 32, 0.88), rgba(12, 12, 20, 0.78));
+  box-shadow:
+    0 32px 120px -48px rgba(255, 118, 214, 0.55),
+    0 0 0 1px rgba(102, 243, 255, 0.18) inset;
+  padding: clamp(1.5rem, 3vw, 2.75rem);
+  color: rgba(226, 233, 255, 0.94);
+  overflow: hidden;
+}
+
+body[data-fold-mode="fold-cover"] .shame-dossier-overlay {
+  align-items: stretch;
+  padding: 1rem;
+}
+
+body[data-fold-mode="fold-cover"] .shame-dossier-panel {
+  border-radius: 1.75rem;
+  max-height: none;
+  height: 100%;
+  padding: clamp(1.25rem, 4vw, 2rem);
+}
+
+body[data-fold-mode="fold-inner"] .shame-dossier-panel {
+  max-width: min(860px, 78vw);
+}
+
+.shame-dossier-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.shame-dossier-heading {
+  flex: 1 1 280px;
+}
+
+.shame-dossier-heading h2 {
+  font-family: var(--font-display, 'Rajdhani', sans-serif);
+  font-size: clamp(1.6rem, 2.4vw, 2.4rem);
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+  margin-bottom: 0.35rem;
+}
+
+.shame-dossier-caption {
+  font-size: 0.8rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(226, 233, 255, 0.7);
+}
+
+.shame-dossier-whisper {
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255, 118, 214, 0.72);
+}
+
+.shame-dossier-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.shame-dossier-filter select {
+  @apply rounded-full border border-white/10 bg-white/10 px-4 py-2 text-[0.65rem] uppercase tracking-[0.35em] text-slate-200;
+  backdrop-filter: blur(12px);
+}
+
+.shame-dossier-clear {
+  @apply rounded-full border border-rose-400/40 bg-rose-500/15 px-4 py-2 text-[0.6rem] uppercase tracking-[0.35em] text-rose-200 transition-colors;
+}
+
+.shame-dossier-clear:hover,
+.shame-dossier-clear:focus-visible {
+  @apply border-rose-300 bg-rose-500/25 text-white outline-none;
+}
+
+.shame-dossier-close {
+  @apply inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/20 bg-white/10 text-base text-slate-100;
+  transition: transform 0.35s cubic-bezier(.4,-0.2,.2,1.2), background-color 0.35s cubic-bezier(.4,-0.2,.2,1.2);
+}
+
+.shame-dossier-close:hover,
+.shame-dossier-close:focus-visible {
+  @apply border-white/40 bg-white/20 outline-none;
+  transform: translateY(-2px);
+}
+
+.shame-dossier-content {
+  position: relative;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding-right: clamp(0.25rem, 1vw, 0.75rem);
+  scrollbar-width: thin;
+}
+
+.shame-dossier-timeline {
+  position: relative;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.shame-dossier-timeline::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 calc(0.85rem - 1px);
+  width: 2px;
+  background: linear-gradient(180deg, rgba(102, 243, 255, 0.35), rgba(255, 118, 214, 0.2));
+  opacity: 0.65;
+}
+
+.shame-dossier-entry {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1.1rem;
+  padding-left: 1.25rem;
+  animation: dossier-reveal 0.55s cubic-bezier(.4,-0.2,.2,1.2) both;
+}
+
+.shame-dossier-entry__marker {
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 9999px;
+  margin-top: 0.35rem;
+  background: linear-gradient(135deg, rgba(102, 243, 255, 0.95), rgba(255, 118, 214, 0.75));
+  box-shadow: 0 0 14px rgba(102, 243, 255, 0.6);
+}
+
+.shame-dossier-entry__body {
+  background: rgba(10, 12, 24, 0.72);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(102, 243, 255, 0.12);
+  padding: 1rem 1.25rem;
+  box-shadow: 0 12px 45px -28px rgba(0, 0, 0, 0.85);
+  backdrop-filter: blur(12px);
+}
+
+.shame-dossier-entry__body header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.shame-dossier-entry__body h3 {
+  font-size: 0.95rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.shame-dossier-entry__body time {
+  font-size: 0.7rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: rgba(226, 233, 255, 0.6);
+}
+
+.shame-dossier-entry__body p {
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: rgba(226, 233, 255, 0.88);
+}
+
+.shame-dossier-entry__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.shame-dossier-meta {
+  font-size: 0.65rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: rgba(226, 233, 255, 0.64);
+  background: rgba(102, 243, 255, 0.08);
+  border-radius: 9999px;
+  padding: 0.25rem 0.75rem;
+}
+
+.shame-dossier-entry.is-cyan .shame-dossier-entry__marker {
+  background: linear-gradient(135deg, rgba(102, 243, 255, 0.95), rgba(102, 243, 255, 0.6));
+  box-shadow: 0 0 14px rgba(102, 243, 255, 0.7);
+}
+
+.shame-dossier-entry.is-pink .shame-dossier-entry__marker {
+  background: linear-gradient(135deg, rgba(255, 118, 214, 0.95), rgba(255, 118, 214, 0.65));
+  box-shadow: 0 0 14px rgba(255, 118, 214, 0.65);
+}
+
+.shame-dossier-entry.is-red .shame-dossier-entry__marker {
+  background: linear-gradient(135deg, rgba(255, 84, 101, 0.95), rgba(255, 118, 118, 0.65));
+  box-shadow: 0 0 14px rgba(255, 84, 101, 0.65);
+}
+
+.shame-dossier-entry.is-violet .shame-dossier-entry__marker {
+  background: linear-gradient(135deg, rgba(175, 128, 255, 0.95), rgba(118, 102, 255, 0.65));
+  box-shadow: 0 0 14px rgba(175, 128, 255, 0.65);
+}
+
+.shame-dossier-entry.is-teal .shame-dossier-entry__marker {
+  background: linear-gradient(135deg, rgba(102, 243, 200, 0.95), rgba(82, 225, 255, 0.6));
+  box-shadow: 0 0 14px rgba(102, 243, 200, 0.6);
+}
+
+.shame-dossier-entry.is-slate .shame-dossier-entry__marker {
+  background: linear-gradient(135deg, rgba(160, 174, 203, 0.85), rgba(122, 138, 176, 0.55));
+  box-shadow: 0 0 14px rgba(160, 174, 203, 0.55);
+}
+
+.shame-dossier-empty {
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: 3rem 1rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(226, 233, 255, 0.5);
+}
+
+@keyframes dossier-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shame-dossier-overlay {
+    transition: none;
+  }
+  .shame-dossier-entry {
+    animation: none;
+  }
+  .shame-dossier-close {
+    transition: none;
+  }
 }
 
 /* Favorites button styling */


### PR DESCRIPTION
## Summary
- add a dossier control to the command bar and register a glassmorphic `<te-shame-dossier>` overlay fed by local and in-memory logs
- dispatch structured dossier events from tags, favorites, gallery pagination, and humiliation taunts while persisting entries in `localStorage`
- style the dossier timeline, expand TTS whisper catalog with dossier lines, and document usage in the README

## Testing
- `npm test` *(fails: modules/tts-toggle.js expects DOM toggle control in test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68ea073d0958832ca0b8974db4bd9913