### PR TITLE
Add streak progression tracking and holographic badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ A modern, visually unified web app for exploring, filtering, and discovering art
 - A "Reset pressure" control sits in the landing meter for quick purges. Clearing the namespace manually (`localStorage.removeItem('tx:haze:v1')`) also wipes the counter if you prefer using dev tools.
 - Motion is throttled automatically when `prefers-reduced-motion` is active or when the in-app motion toggle is set to Reduced, keeping the glow collapse gentle on the Fold cover screen.
 
+## Captive Archive Streaks
+
+- Every day you open the gallery is logged in the shared `tx:haze:v1` namespace under `streakState`. The tracker keeps the current count, the longest chain, and a capped history of day-start timestamps—never more than 32 entries.
+- The command bar now surfaces an animated holographic streak badge. Click or tap it (or the matching Cover screen button) to opt into or out of tracking. When disabled the UI drops into **Ghost mode** and no new visits are persisted.
+- Streak tiers (Dormant → Ember Drift → Glass Glow → Infra Inferno → Void Crown) unlock harsher taunts and rare artist spotlights. They also raise the floor for Azure whisper intensity, so the audio digs deeper the longer you return.
+- QA shortcuts live in the console: `window.txStreaks.recordVisit(daysAgo)` simulates a visit offset, `window.txStreaks.setEnabled(false)` flips ghost mode, and `window.txStreaks.getState()` surfaces the raw persisted payload for time-travel debugging.
+- Streak data is strictly local. Delete it by clearing the namespace (`localStorage.removeItem('tx:haze:v1')`) or by toggling Ghost mode before you browse.
+
 ## Project Structure
 
 - `index.html` – Main entry point with inline Tailwind Play config and component layers (no build step required)

--- a/docs/streaks-qa.md
+++ b/docs/streaks-qa.md
@@ -1,0 +1,60 @@
+# Captive Archive Streak QA Guide
+
+This checklist covers the streak tracker introduced on the gallery page. It verifies persistence, privacy toggles, and tie-ins to taunts/TTS.
+
+## Storage + Namespace
+
+- Streak metadata lives in the shared namespace `localStorage['tx:haze:v1']` under the keys `streakState` and `streakOptOut`.
+- `streakState` holds:
+  - `count`: current consecutive-day streak (integer)
+  - `longest`: best streak observed
+  - `lastVisit`: local midnight timestamp (ms) of the most recent day counted
+  - `history`: up to 32 day-start timestamps (ms) for QA/time-travel validation
+- Ghost mode (opt-out) toggles `streakOptOut` to `true` without mutating the stored counts. When ghosted the module skips persistence and emits `reason: 'opted-out'` events.
+
+## QA Shortcuts
+
+Open the gallery console and use the global helpers:
+
+```js
+// simulate visits
+window.txStreaks.recordVisit(0);      // today
+window.txStreaks.recordVisit(1);      // yesterday
+window.txStreaks.recordVisit(7);      // one week ago
+
+// inspect state
+window.txStreaks.getState();          // returns { count, longest, history, lastVisit }
+window.txStreaks.tiers;               // array of tier metadata (id, min, label)
+
+// toggle privacy
+window.txStreaks.setEnabled(false);   // ghost mode
+window.txStreaks.setEnabled(true);    // resume tracking
+```
+
+For time-travel QA, chain multiple `recordVisit` calls with descending offsets (e.g. `3,2,1,0`) to emulate consecutive days without changing your system clock. The tracker normalises to local midnight, so offsets measured in whole days are sufficient.
+
+## Event Contracts
+
+- Every mutation emits a `window` `CustomEvent('streaks:change', { detail })` where `detail` includes:
+  - `state`, `previousState`
+  - `trackingEnabled`, `tier`, `previousTier`
+  - `didIncrement`, `wasReset`, `deltaDays`, `reason`
+- Gallery bootstrap surfaces toast + whisper feedback when `detail.didIncrement === true`.
+- Toggling ghost mode emits `reason: 'toggle'` events so downstream listeners can update UI immediately.
+
+## UI Expectations
+
+- Command bar badge should read `DAY CAPTURED` on day 1, `DAY STREAK` afterwards. Ghost mode swaps the label to `GHOST MODE` and the count to `—`.
+- Cover toolbar button mirrors the same state and toggles tracking with a single tap.
+- `prefers-reduced-motion` (or the in-app Motion toggle) removes the holographic spin/pulse animation without collapsing layout.
+
+## Humiliation / TTS Hooks
+
+- High streak tiers feed harsher taunts (`humiliation:taunt`) and trigger rare spotlights sourced from `artists.json`. Spotlights throttle to once every three minutes.
+- `modules/tts-dispatcher` raises the minimum whisper lane according to streak tier, so Azure voices escalate in tandem with your chain.
+- `dispatchWhisperEvent('streak_increment', { text })` fires on each increment; check caption overlays when audio is muted.
+
+## Reset + Cleanup
+
+- Clear the streak quickly with `localStorage.removeItem('tx:haze:v1')` or by wiping just the `streakState` key via devtools storage editor.
+- Ghost mode prevents any writes while active. Reactivate tracking to resume counting without losing the previous streak record.

--- a/modules/components/command-bar.js
+++ b/modules/components/command-bar.js
@@ -50,6 +50,25 @@ template.innerHTML = `
             FETCH
           </button>
         </div>
+        <div class="command-streak" role="group" aria-label="Return streak tracker">
+          <button
+            id="streak-chip"
+            class="control-btn command-btn streak-chip"
+            type="button"
+            aria-pressed="true"
+            aria-describedby="streak-announcement"
+            aria-label="Disable streak tracking"
+          >
+            <span class="streak-chip__halo" aria-hidden="true"></span>
+            <span class="streak-chip__core" aria-hidden="true"></span>
+            <span class="streak-chip__label" aria-hidden="true">
+              <span class="streak-chip__value" data-streak-count>0</span>
+              <span class="streak-chip__suffix" data-streak-label>DAY STREAK</span>
+              <span class="streak-chip__tier" data-streak-tier>—</span>
+            </span>
+          </button>
+          <span class="sr-only" id="streak-announcement" data-streak-announcer aria-live="polite"></span>
+        </div>
         <div class="command-status" aria-live="polite">
           <span class="command-status__label" data-mode="cover">COVER MODE</span>
           <span class="command-status__label" data-mode="inner">INNER MODE</span>
@@ -89,6 +108,23 @@ template.innerHTML = `
           <span aria-hidden="true">⛓</span>
           <span class="cover-command-label">Filters</span>
         </button>
+        <button
+          id="cover-streak-btn"
+          class="cover-command-btn cover-streak-btn"
+          type="button"
+          aria-pressed="true"
+          aria-describedby="cover-streak-announcement"
+        >
+          <span class="cover-streak-orb" aria-hidden="true"></span>
+          <span class="cover-streak-count" data-streak-count>0</span>
+          <span class="cover-command-label">Streak</span>
+        </button>
+        <span
+          class="sr-only"
+          id="cover-streak-announcement"
+          data-streak-announcer
+          aria-live="polite"
+        ></span>
         <button
           id="cover-mute-btn"
           class="cover-command-btn cover-mute-toggle"

--- a/modules/humiliation.js
+++ b/modules/humiliation.js
@@ -2,9 +2,138 @@
 
 import { showToast, getCopiedCount } from "./sidebar.js";
 import { getActiveTags } from "./tags.js";
+import {
+  getStreakState,
+  getStreakTier,
+  onStreakChange as onStreakUpdate,
+  isStreakTrackingEnabled,
+} from "./progression/streaks.js";
 
 const TAUNT_DEDUPE_MS = 4200;
 let lastTauntDetail = { message: "", at: 0 };
+
+const STREAK_TAUNTS = [
+  [],
+  [
+    ({ count }) => `Day ${count}. You really set an alarm for this glow?`,
+    ({ count }) => `${count} nights in a row and you still call it "just browsing"?`,
+  ],
+  [
+    ({ count }) => `\u2727 Day ${count}. Even the archive knows your name now.`,
+    ({ count }) => `That ${count}-day chain is tightening. Keep pretending it's research.`,
+  ],
+  [
+    ({ count }) => `Infra tier unlocked after ${count} days. The gallery expected nothing less.`,
+    ({ count }) => `You carried the streak ${count} days. Enjoy the burn you begged for.`,
+  ],
+  [
+    ({ count }) => `${count} days without missing. Void crown granted. You're part of the exhibit now.`,
+    ({ count }) => `Thirty-plus? ${count} days tells on you louder than any whisper ever could.`,
+  ],
+];
+
+const SPOTLIGHT_COOLDOWN_MS = 180000;
+
+let streakSnapshot = { count: 0, longest: 0 };
+let streakTier = 0;
+let streakTrackingEnabled = true;
+let spotlightCatalog = [];
+let lastSpotlightName = null;
+let lastSpotlightAt = 0;
+
+function normalizeArtistEntry(entry) {
+  if (!entry || typeof entry !== "object") return null;
+  const name = entry.artistName || entry.name;
+  if (!name || typeof name !== "string") return null;
+  const tags = Array.isArray(entry.kinkTags)
+    ? entry.kinkTags.filter((tag) => typeof tag === "string")
+    : [];
+  const postCount = Number(entry.postCount) || 0;
+  return { name, tags, postCount };
+}
+
+function setHumiliationArtists(entries = []) {
+  if (!Array.isArray(entries)) {
+    spotlightCatalog = [];
+    return;
+  }
+  spotlightCatalog = entries
+    .map((entry) => normalizeArtistEntry(entry))
+    .filter(Boolean);
+}
+
+function handleStreakUpdate(detail) {
+  if (!detail || typeof detail !== "object") return;
+  if (detail.state && typeof detail.state === "object") {
+    streakSnapshot = {
+      ...streakSnapshot,
+      count: Number(detail.state.count) || 0,
+      longest: Number(detail.state.longest) || streakSnapshot.longest || 0,
+    };
+  }
+  streakTrackingEnabled = Boolean(detail.trackingEnabled);
+  streakTier = detail.trackingEnabled ? Number(detail.tier) || 0 : 0;
+}
+
+try {
+  streakSnapshot = getStreakState();
+  streakTier = getStreakTier();
+  streakTrackingEnabled = isStreakTrackingEnabled();
+  onStreakUpdate((detail) => handleStreakUpdate(detail));
+} catch (error) {
+  console.warn("[humiliation] streak integration unavailable", error);
+}
+
+function pickFromPool(pool) {
+  if (!Array.isArray(pool) || pool.length === 0) return null;
+  return pool[Math.floor(Math.random() * pool.length)];
+}
+
+function getStreakTaunt() {
+  if (!streakTrackingEnabled) return null;
+  const count = Number(streakSnapshot?.count) || 0;
+  if (count <= 0) return null;
+  const tierIndex = streakTier > 0 ? Math.min(streakTier, STREAK_TAUNTS.length - 1) : count >= 2 ? 1 : 0;
+  const pool = STREAK_TAUNTS[tierIndex] || [];
+  if (!pool.length) return null;
+  const template = pickFromPool(pool);
+  if (typeof template === "function") {
+    return template({ count, tier: streakTier });
+  }
+  if (typeof template === "string") {
+    return template.replace("{count}", count);
+  }
+  return null;
+}
+
+function pickSpotlightArtist() {
+  if (!spotlightCatalog.length) return null;
+  const highFocus = spotlightCatalog.filter((artist) => artist.postCount >= 120);
+  const pool = streakTier >= 3 && highFocus.length ? highFocus : spotlightCatalog;
+  let candidate = null;
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const pick = pickFromPool(pool);
+    if (!pick) break;
+    if (!lastSpotlightName || pick.name !== lastSpotlightName || attempt === 3) {
+      candidate = pick;
+      break;
+    }
+  }
+  return candidate;
+}
+
+function getSpotlightTaunt() {
+  if (!streakTrackingEnabled || streakTier < 2 || !spotlightCatalog.length) return null;
+  const now = Date.now();
+  if (now - lastSpotlightAt < SPOTLIGHT_COOLDOWN_MS) return null;
+  const artist = pickSpotlightArtist();
+  if (!artist) return null;
+  lastSpotlightAt = now;
+  lastSpotlightName = artist.name;
+  const tags = (artist.tags || []).slice(0, 3).map((tag) => tag.replace(/_/g, " "));
+  const tagLine = tags.length ? tags.join(", ") : "whatever filth you crave";
+  return `Spotlight fixated on ${artist.name} — drenched in ${tagLine}.`;
+}
 
 function dispatchTauntEvent(message, detail = {}) {
   if (typeof document === "undefined" || !message) return;
@@ -48,6 +177,14 @@ function startTauntTicker(taunts = [], intervalMs = 30000) {
     if (copies > 0) {
       dynamic.push(`Copied ${copies} artists already? Desperate much?`);
     }
+    const streakLine = getStreakTaunt();
+    if (streakLine) {
+      dynamic.push(streakLine);
+    }
+    const spotlightLine = getSpotlightTaunt();
+    if (spotlightLine) {
+      dynamic.push(spotlightLine);
+    }
     const pool = tauntPool.concat(dynamic);
     const msg = pool[Math.floor(Math.random() * pool.length)];
     if (msg) {
@@ -63,4 +200,4 @@ function startTauntTicker(taunts = [], intervalMs = 30000) {
 
 // No unused or undefined functions in this file.
 
-export { startTauntTicker };
+export { startTauntTicker, setHumiliationArtists };

--- a/modules/pages/gallery.js
+++ b/modules/pages/gallery.js
@@ -51,7 +51,7 @@ import {
   persistGalleryState,
   restoreGalleryState,
 } from '../api.js';
-import { startTauntTicker } from '../humiliation.js';
+import { startTauntTicker, setHumiliationArtists } from '../humiliation.js';
 import { createTTSToggleButton, createTTSIntensityControl } from '../tts-toggle.js';
 import {
   initTagExplorer,
@@ -74,6 +74,15 @@ import {
   getDossierEntries,
 } from '../shame-dossier.js';
 import { incrementPressure } from '../progression/pressure-meter.js';
+import {
+  recordVisit as recordStreakVisit,
+  getStreakState as getStreakSnapshot,
+  getStreakTier as getCurrentStreakTier,
+  getStreakTierInfo,
+  isStreakTrackingEnabled,
+  setStreakTrackingEnabled,
+  onStreakChange as onStreakUpdate,
+} from '../progression/streaks.js';
 
 const MOTION_STORAGE_KEY = 'te.motion.preference';
 const MOTION_DEFAULT = 'full';
@@ -750,6 +759,199 @@ function setupMotionToggle(initialMode) {
   };
 }
 
+function formatArtistTags(artist, { limit = 2 } = {}) {
+  if (!artist || !Array.isArray(artist.kinkTags) || artist.kinkTags.length === 0) {
+    return '';
+  }
+  const safeLimit = Math.max(1, Math.min(limit, artist.kinkTags.length));
+  return artist.kinkTags
+    .slice(0, safeLimit)
+    .map((tag) => tag.replace(/_/g, ' '))
+    .join(', ');
+}
+
+function selectSpotlightForWhisper(artists = [], tier = 0) {
+  if (!Array.isArray(artists) || artists.length === 0) {
+    return null;
+  }
+  const threshold = tier >= 3 ? 180 : tier >= 2 ? 120 : 60;
+  const preferred = artists.filter((artist) => Number(artist.postCount) >= threshold);
+  const pool = preferred.length ? preferred : artists;
+  if (!pool.length) return null;
+  return pool[Math.floor(Math.random() * pool.length)];
+}
+
+function createStreakWhisperLine(detail, artists = []) {
+  if (!detail || !detail.trackingEnabled || !detail.didIncrement) return null;
+  const count = Number(detail.state?.count) || 0;
+  const info = getStreakTierInfo(count);
+  let baseLine;
+  if (detail.wasReset && count === 1) {
+    baseLine = 'Chain snapped and you crawled back anyway. Day one is already logged again.';
+  } else if (count === 1) {
+    baseLine = 'Day one recorded. You barely hesitated before indulging again.';
+  } else {
+    baseLine = `Day ${count}. ${info.label} tier acknowledged.`;
+  }
+  if ((detail.tier || 0) < 2) {
+    return baseLine;
+  }
+  const spotlight = selectSpotlightForWhisper(artists, detail.tier || 0);
+  if (!spotlight) return baseLine;
+  const tagLine = formatArtistTags(spotlight, { limit: detail.tier >= 3 ? 3 : 2 });
+  if (tagLine) {
+    return `${baseLine} Spotlight ${spotlight.artistName} drowning in ${tagLine}.`;
+  }
+  return `${baseLine} Spotlight ${spotlight.artistName}.`;
+}
+
+function formatStreakToast(detail) {
+  if (!detail) return null;
+  if (detail.reason === 'toggle') {
+    return detail.trackingEnabled
+      ? 'Streak tracking resumed. Every visit counts again.'
+      : 'Streak tracking paused. Ghost mode engaged.';
+  }
+  if (!detail.trackingEnabled) return null;
+  if (detail.reason === 'opted-out' || detail.reason === 'invalid') return null;
+  const count = Number(detail.state?.count) || 0;
+  if (detail.wasReset && detail.didIncrement && count === 1) {
+    return 'Chain snapped. Back to day one.';
+  }
+  if (!detail.didIncrement) return null;
+  const info = getStreakTierInfo(count);
+  let message = `Day ${count}: ${info.label} tier engaged.`;
+  if (info.nextThreshold && info.nextThreshold > count) {
+    const remaining = info.nextThreshold - count;
+    const nextInfo = getStreakTierInfo(info.nextThreshold);
+    message += ` ${remaining} more day${remaining === 1 ? '' : 's'} to ${nextInfo.label}.`;
+  }
+  return message;
+}
+
+function setupStreakBadges({ initialDetail } = {}) {
+  const innerChip = document.getElementById('streak-chip');
+  const coverChip = document.getElementById('cover-streak-btn');
+  if (!innerChip && !coverChip) {
+    return () => {};
+  }
+
+  const announcers = Array.from(document.querySelectorAll('[data-streak-announcer]'));
+  const innerValue = innerChip?.querySelector('[data-streak-count]');
+  const innerTier = innerChip?.querySelector('[data-streak-tier]');
+  const innerLabel = innerChip?.querySelector('[data-streak-label]');
+  const coverValue = coverChip?.querySelector('[data-streak-count]');
+
+  const applyDetail = (detail) => {
+    const trackingEnabled = detail?.trackingEnabled !== false && isStreakTrackingEnabled();
+    const count = trackingEnabled ? Math.max(0, Number(detail?.state?.count) || 0) : 0;
+    const tierInfo = trackingEnabled ? getStreakTierInfo(count) : getStreakTierInfo(0);
+    const tierLabel = tierInfo?.label || 'Dormant';
+    const summary = trackingEnabled
+      ? `Day ${count} streak. ${tierLabel}.`
+      : 'Streak tracking paused.';
+
+    announcers.forEach((node) => {
+      if (node) node.textContent = summary;
+    });
+
+    if (innerChip) {
+      innerChip.setAttribute('aria-pressed', trackingEnabled ? 'true' : 'false');
+      innerChip.setAttribute(
+        'aria-label',
+        trackingEnabled
+          ? `Disable streak tracking. Day ${count} — ${tierLabel}.`
+          : 'Enable streak tracking. Ghost mode active.',
+      );
+      if (trackingEnabled && tierInfo?.id) {
+        innerChip.dataset.tier = tierInfo.id;
+      } else {
+        delete innerChip.dataset.tier;
+      }
+      if (innerValue) innerValue.textContent = trackingEnabled ? String(count) : '—';
+      if (innerTier) innerTier.textContent = trackingEnabled ? tierLabel.toUpperCase() : 'GHOST MODE';
+      if (innerLabel) innerLabel.textContent = count === 1 ? 'DAY CAPTURED' : 'DAY STREAK';
+    }
+
+    if (coverChip) {
+      coverChip.setAttribute('aria-pressed', trackingEnabled ? 'true' : 'false');
+      coverChip.setAttribute(
+        'aria-label',
+        trackingEnabled
+          ? `Toggle streak tracking off. ${count} day chain, ${tierLabel}.`
+          : 'Toggle streak tracking on. Streak tracking paused.',
+      );
+      if (trackingEnabled && tierInfo?.id) {
+        coverChip.dataset.tier = tierInfo.id;
+      } else {
+        delete coverChip.dataset.tier;
+      }
+      if (coverValue) coverValue.textContent = trackingEnabled ? String(count) : '—';
+    }
+  };
+
+  const handleClick = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setStreakTrackingEnabled(!isStreakTrackingEnabled());
+  };
+
+  if (innerChip) innerChip.addEventListener('click', handleClick);
+  if (coverChip) coverChip.addEventListener('click', handleClick);
+
+  const unsubscribe = onStreakUpdate((detail) => applyDetail(detail));
+
+  applyDetail(
+    initialDetail || {
+      state: getStreakSnapshot(),
+      trackingEnabled: isStreakTrackingEnabled(),
+      tier: getCurrentStreakTier(),
+    },
+  );
+
+  return () => {
+    if (innerChip) innerChip.removeEventListener('click', handleClick);
+    if (coverChip) coverChip.removeEventListener('click', handleClick);
+    if (typeof unsubscribe === 'function') unsubscribe();
+  };
+}
+
+function setupStreakSystem({ artists }) {
+  const visitDetail = recordStreakVisit({ reason: 'gallery:init', emit: true });
+  const badgeCleanup = setupStreakBadges({ initialDetail: visitDetail });
+
+  const handleDetail = (detail) => {
+    if (!detail) return;
+    const toast = formatStreakToast(detail);
+    if (toast) {
+      showToast(toast);
+    }
+    if (detail.trackingEnabled && detail.didIncrement) {
+      triggerBassPulse(Math.min(1, 0.35 + (detail.tier || 0) * 0.18));
+      const whisperLine = createStreakWhisperLine(detail, artists);
+      if (whisperLine) {
+        dispatchWhisperEvent('streak_increment', {
+          text: whisperLine,
+          minIntensity: Math.max(1, detail.tier || 1),
+          maxIntensity: 3,
+          cooldownMs: 4600,
+        });
+      }
+    }
+  };
+
+  if (visitDetail) {
+    handleDetail(visitDetail);
+  }
+
+  const unsubscribe = onStreakUpdate((detail) => handleDetail(detail));
+
+  return () => {
+    if (typeof badgeCleanup === 'function') badgeCleanup();
+    if (typeof unsubscribe === 'function') unsubscribe();
+  };
+}
+
 // Settings sheet removed - functionality now only in inner command bar
 
 function updateCommandStatusLabels(mode) {
@@ -968,12 +1170,14 @@ export async function initGalleryPage({ foldAdapter } = {}) {
   setTagTooltips(tooltips);
   setTagTaunts(tagTaunts);
   setTaunts(generalTaunts);
+  setHumiliationArtists(artists);
   configureWhisperCatalog({
     events: ttsLines,
     tags: tagTaunts,
     generalTaunts,
   });
   startTauntTicker(generalTaunts, 30000);
+  const streakCleanup = setupStreakSystem({ artists });
 
   const quotes = Object.values(tooltips || {}).filter(Boolean);
   if (quotes.length > 0) {
@@ -1083,6 +1287,9 @@ export async function initGalleryPage({ foldAdapter } = {}) {
       }
       if (typeof ritualCleanup === 'function') {
         ritualCleanup();
+      }
+      if (typeof streakCleanup === 'function') {
+        streakCleanup();
       }
     },
   };

--- a/modules/progression/streaks.js
+++ b/modules/progression/streaks.js
@@ -1,0 +1,369 @@
+const STORAGE_KEY = 'tx:haze:v1';
+const STORAGE_STREAK_KEY = 'streakState';
+const STORAGE_PREF_KEY = 'streakOptOut';
+const DAY_MS = 86400000;
+const HISTORY_LIMIT = 32;
+
+const STREAK_TIERS = [
+  { id: 'dormant', label: 'Dormant', min: 0, a11yName: 'Dormant tier', accent: 'muted' },
+  { id: 'ember', label: 'Ember Drift', min: 3, a11yName: 'Ember tier', accent: 'ember' },
+  { id: 'glow', label: 'Glass Glow', min: 7, a11yName: 'Glow tier', accent: 'glow' },
+  { id: 'inferno', label: 'Infra Inferno', min: 14, a11yName: 'Inferno tier', accent: 'inferno' },
+  { id: 'void', label: 'Void Crown', min: 30, a11yName: 'Void Crown tier', accent: 'void' },
+];
+
+let hydrated = false;
+let storageFaultLogged = false;
+let listeners = new Set();
+let state = {
+  count: 0,
+  longest: 0,
+  lastVisit: null,
+  history: [],
+};
+let trackingOptOut = false;
+
+function cloneState(source = {}) {
+  return {
+    count: Number(source.count) || 0,
+    longest: Number(source.longest) || 0,
+    lastVisit: typeof source.lastVisit === 'number' ? source.lastVisit : null,
+    history: Array.isArray(source.history)
+      ? source.history
+          .map((value) => Number(value))
+          .filter((value) => Number.isFinite(value))
+          .slice(-HISTORY_LIMIT)
+      : [],
+  };
+}
+
+function readNamespace() {
+  if (typeof window === 'undefined' || !window.localStorage) return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return {};
+    return parsed;
+  } catch (error) {
+    if (!storageFaultLogged) {
+      console.warn('[streaks] failed to read namespace', error);
+      storageFaultLogged = true;
+    }
+    return {};
+  }
+}
+
+function writeNamespace() {
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  const payload = readNamespace();
+  payload[STORAGE_STREAK_KEY] = { ...state };
+  payload[STORAGE_PREF_KEY] = trackingOptOut === true;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    if (!storageFaultLogged) {
+      console.warn('[streaks] failed to persist namespace', error);
+      storageFaultLogged = true;
+    }
+  }
+}
+
+function getDayStart(timestamp) {
+  const value = Number(timestamp);
+  if (!Number.isFinite(value) || value <= 0) return null;
+  const date = new Date(value);
+  date.setHours(0, 0, 0, 0);
+  const normalized = date.getTime();
+  return Number.isFinite(normalized) ? normalized : null;
+}
+
+function computeTierFromCount(count) {
+  const numeric = Number(count) || 0;
+  let tier = 0;
+  for (let index = STREAK_TIERS.length - 1; index >= 0; index -= 1) {
+    const entry = STREAK_TIERS[index];
+    if (!entry) continue;
+    if (numeric >= entry.min) {
+      tier = index;
+      break;
+    }
+  }
+  return tier;
+}
+
+function ensureHydrated() {
+  if (hydrated) return;
+  hydrated = true;
+  const namespace = readNamespace();
+  const storedState = cloneState(namespace?.[STORAGE_STREAK_KEY] || {});
+  state = {
+    ...storedState,
+    count: Math.max(0, Math.round(storedState.count || 0)),
+    longest: Math.max(0, Math.round(storedState.longest || storedState.count || 0)),
+  };
+  trackingOptOut = namespace?.[STORAGE_PREF_KEY] === true;
+}
+
+function snapshotState(source = state) {
+  return {
+    count: source.count,
+    longest: source.longest,
+    lastVisit: source.lastVisit,
+    history: Array.isArray(source.history) ? [...source.history] : [],
+  };
+}
+
+function buildDetail({
+  previousState = snapshotState(state),
+  reason = 'update',
+  timestamp = Date.now(),
+  didIncrement = false,
+  wasReset = false,
+  deltaDays = 0,
+} = {}) {
+  const trackingEnabled = !trackingOptOut;
+  const tier = trackingEnabled ? computeTierFromCount(state.count) : 0;
+  const previousTier = computeTierFromCount(previousState.count);
+  return {
+    state: snapshotState(state),
+    previousState: snapshotState(previousState),
+    trackingEnabled,
+    tier,
+    previousTier: trackingEnabled ? previousTier : 0,
+    didIncrement,
+    wasReset,
+    deltaDays,
+    reason,
+    optedOut: !trackingEnabled,
+    timestamp,
+  };
+}
+
+function notify(detail) {
+  listeners.forEach((listener) => {
+    try {
+      listener(detail);
+    } catch (error) {
+      console.warn('[streaks] listener failed', error);
+    }
+  });
+  if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+    try {
+      window.dispatchEvent(new CustomEvent('streaks:change', { detail }));
+    } catch (error) {
+      console.warn('[streaks] failed to dispatch change event', error);
+    }
+  }
+}
+
+function trimHistory() {
+  if (!Array.isArray(state.history)) {
+    state.history = [];
+    return;
+  }
+  if (state.history.length > HISTORY_LIMIT) {
+    state.history = state.history.slice(-HISTORY_LIMIT);
+  }
+}
+
+function recordVisit({ timestamp = Date.now(), reason = 'visit', emit = true } = {}) {
+  ensureHydrated();
+  const visitAt = getDayStart(timestamp);
+  if (!Number.isFinite(visitAt)) {
+    return buildDetail({ reason: 'invalid', timestamp });
+  }
+  const previousState = snapshotState(state);
+  if (trackingOptOut) {
+    const detail = buildDetail({ previousState, reason: 'opted-out', timestamp, didIncrement: false, wasReset: false });
+    if (emit) {
+      notify(detail);
+    }
+    return detail;
+  }
+
+  const lastVisitDay = getDayStart(state.lastVisit);
+  let didIncrement = false;
+  let wasReset = false;
+  let deltaDays = 0;
+
+  if (!Number.isFinite(lastVisitDay)) {
+    state.count = Math.max(1, state.count || 1);
+    state.history = [visitAt];
+    didIncrement = true;
+  } else {
+    deltaDays = Math.round((visitAt - lastVisitDay) / DAY_MS);
+    if (deltaDays <= 0) {
+      // Same day revisit; ensure we have a record but do not increment.
+      if (!state.history.includes(visitAt)) {
+        state.history.push(visitAt);
+        trimHistory();
+      }
+    } else if (deltaDays === 1) {
+      state.count = Math.max(0, state.count) + 1;
+      state.history.push(visitAt);
+      trimHistory();
+      didIncrement = true;
+    } else if (deltaDays > 1) {
+      state.count = 1;
+      state.history.push(visitAt);
+      trimHistory();
+      wasReset = true;
+      didIncrement = true;
+    }
+  }
+
+  state.lastVisit = visitAt;
+  if (state.count > state.longest) {
+    state.longest = state.count;
+  }
+  writeNamespace();
+
+  const detail = buildDetail({
+    previousState,
+    reason,
+    timestamp: visitAt,
+    didIncrement,
+    wasReset,
+    deltaDays,
+  });
+  if (emit) {
+    notify(detail);
+  }
+  return detail;
+}
+
+function setStreakTrackingEnabled(enabled, { silent = false } = {}) {
+  ensureHydrated();
+  const nextOptOut = !enabled;
+  if (trackingOptOut === nextOptOut) {
+    return buildDetail({ reason: 'noop-toggle' });
+  }
+  const previousState = snapshotState(state);
+  trackingOptOut = nextOptOut;
+  writeNamespace();
+  const detail = buildDetail({
+    previousState,
+    reason: 'toggle',
+    didIncrement: false,
+    wasReset: false,
+  });
+  detail.toggled = true;
+  detail.optedOut = nextOptOut;
+  if (!silent) {
+    notify(detail);
+  }
+  return detail;
+}
+
+function isStreakTrackingEnabled() {
+  ensureHydrated();
+  return !trackingOptOut;
+}
+
+function getStreakState() {
+  ensureHydrated();
+  return snapshotState(state);
+}
+
+function getStreakTier() {
+  ensureHydrated();
+  if (trackingOptOut) return 0;
+  return computeTierFromCount(state.count);
+}
+
+function getStreakTierInfo(count = state.count) {
+  const tierIndex = computeTierFromCount(count);
+  const tier = STREAK_TIERS[tierIndex] || STREAK_TIERS[0];
+  const nextTier = STREAK_TIERS[tierIndex + 1] || null;
+  return {
+    ...tier,
+    tier: tierIndex,
+    nextThreshold: nextTier ? nextTier.min : null,
+  };
+}
+
+function getTierCatalog() {
+  return STREAK_TIERS.map((entry, index) => ({ ...entry, tier: index }));
+}
+
+function onStreakChange(callback) {
+  if (typeof callback !== 'function') return () => {};
+  ensureHydrated();
+  listeners.add(callback);
+  return () => {
+    listeners.delete(callback);
+  };
+}
+
+function syncFromStorage(serialized) {
+  if (typeof serialized !== 'string') return;
+  try {
+    const parsed = JSON.parse(serialized);
+    const nextState = cloneState(parsed?.[STORAGE_STREAK_KEY] || {});
+    const nextOptOut = parsed?.[STORAGE_PREF_KEY] === true;
+    const previousState = snapshotState(state);
+    const previousOptOut = trackingOptOut;
+    const changed =
+      nextState.count !== state.count ||
+      nextState.longest !== state.longest ||
+      nextState.lastVisit !== state.lastVisit ||
+      nextState.history.length !== state.history.length ||
+      nextOptOut !== trackingOptOut;
+    state = {
+      ...nextState,
+      count: Math.max(0, Math.round(nextState.count || 0)),
+      longest: Math.max(0, Math.round(nextState.longest || nextState.count || 0)),
+    };
+    trackingOptOut = nextOptOut;
+    if (changed || previousOptOut !== trackingOptOut) {
+      const detail = buildDetail({
+        previousState,
+        reason: 'storage',
+        didIncrement: false,
+        wasReset: false,
+      });
+      notify(detail);
+    }
+  } catch (error) {
+    if (!storageFaultLogged) {
+      console.warn('[streaks] failed to sync storage payload', error);
+      storageFaultLogged = true;
+    }
+  }
+}
+
+if (typeof window !== 'undefined') {
+  ensureHydrated();
+  window.addEventListener('storage', (event) => {
+    if (event.key !== STORAGE_KEY) return;
+    if (event.newValue === event.oldValue) return;
+    syncFromStorage(event.newValue);
+  });
+  const namespace = readNamespace();
+  if (namespace && typeof namespace === 'object') {
+    syncFromStorage(JSON.stringify(namespace));
+  }
+  window.txStreaks = Object.assign(window.txStreaks || {}, {
+    getState: () => getStreakState(),
+    recordVisit: (daysAgo = 0) =>
+      recordVisit({
+        timestamp: Date.now() - Number(daysAgo || 0) * DAY_MS,
+        reason: 'manual',
+      }),
+    setEnabled: (enabled) => setStreakTrackingEnabled(Boolean(enabled)),
+    isEnabled: () => isStreakTrackingEnabled(),
+    tiers: getTierCatalog(),
+  });
+}
+
+export {
+  recordVisit,
+  getStreakState,
+  getStreakTier,
+  getStreakTierInfo,
+  getTierCatalog,
+  isStreakTrackingEnabled,
+  setStreakTrackingEnabled,
+  onStreakChange,
+};

--- a/modules/tts-dispatcher.js
+++ b/modules/tts-dispatcher.js
@@ -11,6 +11,11 @@ import {
   getPressureTier,
   onPressureChange as onPressureStateChange,
 } from './progression/pressure-meter.js';
+import {
+  getStreakTier,
+  onStreakChange as onStreakUpdate,
+  isStreakTrackingEnabled,
+} from './progression/streaks.js';
 
 const LANE_MIN = 1;
 const LANE_MAX = 3;
@@ -48,9 +53,14 @@ let scrollSuppressedUntil = 0;
 let lastScrollY = null;
 let lastScrollEvent = 0;
 let pressureTier = 0;
+let streakTier = 0;
 
 try {
   pressureTier = getPressureTier();
+} catch {}
+
+try {
+  streakTier = isStreakTrackingEnabled() ? getStreakTier() : 0;
 } catch {}
 
 onPressureStateChange((detail) => {
@@ -59,6 +69,11 @@ onPressureStateChange((detail) => {
   if (Number.isFinite(nextTier)) {
     pressureTier = Math.max(0, nextTier);
   }
+});
+
+onStreakUpdate((detail) => {
+  if (!detail || typeof detail.tier === 'undefined') return;
+  streakTier = detail.trackingEnabled ? Math.max(0, Number(detail.tier) || 0) : 0;
 });
 
 function clampLane(value) {
@@ -184,10 +199,13 @@ function resolveLane(userLane, { intensity, minIntensity, maxIntensity } = {}) {
   if (userCap === 0) return 0;
   const pressureFloor =
     pressureTier > 0 ? Math.min(LANE_MAX, clampLane(pressureTier)) : LANE_MIN;
+  const streakFloor =
+    streakTier > 0 ? Math.min(LANE_MAX, clampLane(streakTier)) : LANE_MIN;
+  const combinedFloor = Math.max(pressureFloor, streakFloor);
   if (typeof intensity === 'number') {
     const forced = clampLane(intensity);
     if (forced === 0) return 0;
-    const enforcedFloor = Math.max(pressureFloor, forced);
+    const enforcedFloor = Math.max(combinedFloor, forced);
     if (userCap < enforcedFloor) {
       return userCap;
     }
@@ -195,7 +213,7 @@ function resolveLane(userLane, { intensity, minIntensity, maxIntensity } = {}) {
   }
   const requestedMin = typeof minIntensity === 'number' ? clampLane(minIntensity) : LANE_MIN;
   const requestedMax = typeof maxIntensity === 'number' ? clampLane(maxIntensity) : LANE_MAX;
-  const floor = Math.max(requestedMin, pressureFloor);
+  const floor = Math.max(requestedMin, combinedFloor);
   const ceiling = Math.min(userCap, requestedMax || LANE_MAX);
   if (ceiling === 0) return 0;
   if (ceiling < floor) {

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -184,6 +184,113 @@ box-shadow: 0 18px 45px -25px rgba(255, 118, 214, 0.5);
 .command-group {
 @apply flex flex-wrap items-center justify-center gap-3;
 }
+.command-streak {
+@apply flex flex-wrap items-center justify-center gap-4;
+}
+.streak-chip {
+@apply relative inline-flex items-center justify-center gap-2 overflow-hidden rounded-full border border-cyan-400/40 bg-gradient-to-r from-cyan-500/10 via-fuchsia-400/10 to-sky-400/10 px-4 py-2 text-[0.55rem] font-semibold uppercase tracking-[0.4em] text-cyan-100 shadow-[0_0_25px_rgba(56,189,248,0.35)] transition-all duration-500 ease-kink;
+  min-height: 2.5rem;
+  letter-spacing: 0.35em;
+}
+.streak-chip::after {
+  content: '';
+  position: absolute;
+  inset: -120%;
+  background: conic-gradient(
+    from 0deg,
+    rgba(56, 189, 248, 0.15),
+    rgba(236, 72, 153, 0.2),
+    rgba(129, 140, 248, 0.18),
+    rgba(56, 189, 248, 0.15)
+  );
+  transform: rotate(0deg);
+  animation: streakSpin 12s linear infinite;
+}
+.streak-chip__halo,
+.streak-chip__core {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.streak-chip__halo {
+  background: radial-gradient(circle at 50% 50%, rgba(236, 72, 153, 0.4), transparent 70%);
+  mix-blend-mode: screen;
+  opacity: 0.55;
+  animation: streakPulse 2800ms cubic-bezier(.4,-0.2,.2,1.2) infinite;
+}
+.streak-chip__core {
+  background: linear-gradient(120deg, rgba(59, 130, 246, 0.25), rgba(244, 114, 182, 0.08));
+  opacity: 0.7;
+}
+.streak-chip__label {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+}
+.streak-chip__value {
+  font-size: 1.2rem;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.2em;
+}
+.streak-chip__suffix {
+  font-size: 0.55rem;
+  letter-spacing: 0.45em;
+  opacity: 0.8;
+}
+.streak-chip__tier {
+  font-size: 0.5rem;
+  letter-spacing: 0.5em;
+  opacity: 0.7;
+}
+.streak-chip[aria-pressed="false"] {
+@apply border-white/15 bg-black/40 text-slate-300 shadow-none;
+}
+.streak-chip[aria-pressed="false"]::after,
+.streak-chip[aria-pressed="false"] .streak-chip__halo {
+  opacity: 0;
+  animation: none;
+}
+.streak-chip[data-tier='ember'] {
+  box-shadow: 0 0 32px rgba(251, 191, 36, 0.35);
+}
+.streak-chip[data-tier='glow'] {
+  box-shadow: 0 0 36px rgba(59, 130, 246, 0.45);
+}
+.streak-chip[data-tier='inferno'] {
+  box-shadow: 0 0 38px rgba(239, 68, 68, 0.5);
+}
+.streak-chip[data-tier='void'] {
+  box-shadow: 0 0 45px rgba(244, 114, 182, 0.55);
+}
+@keyframes streakSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@keyframes streakPulse {
+  0%,
+  100% {
+    opacity: 0.45;
+    transform: scale(0.95);
+  }
+  50% {
+    opacity: 0.85;
+    transform: scale(1.08);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .streak-chip::after,
+  .streak-chip__halo {
+    animation: none;
+  }
+}
+body[data-motion='reduced'] .streak-chip::after,
+body[data-motion='reduced'] .streak-chip__halo {
+  animation: none;
+}
 .command-status {
 @apply flex flex-wrap items-center justify-center gap-3 text-[0.55rem] tracking-[0.4em] text-slate-300;
 }
@@ -224,6 +331,58 @@ body[data-fold-mode="fold-cover"] .command-bar-safe-area--top {
 .cover-command-btn span[aria-hidden="true"] {
   font-size: 1rem;
   line-height: 1;
+}
+.cover-streak-btn {
+@apply relative overflow-hidden;
+  min-width: 4.75rem;
+}
+.cover-streak-btn::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at 50% 20%, rgba(56, 189, 248, 0.38), transparent 65%);
+  opacity: 0.65;
+  pointer-events: none;
+  animation: coverStreakGlow 3600ms cubic-bezier(.4,-0.2,.2,1.2) infinite;
+}
+.cover-streak-orb {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(59, 130, 246, 0.8), rgba(236, 72, 153, 0.3));
+  box-shadow: 0 0 18px rgba(59, 130, 246, 0.6);
+}
+.cover-streak-count {
+  font-size: 0.95rem;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.2em;
+}
+.cover-streak-btn[aria-pressed="false"]::before,
+.cover-streak-btn[aria-pressed="false"] .cover-streak-orb {
+  animation: none;
+  opacity: 0.35;
+  box-shadow: none;
+  background: rgba(148, 163, 184, 0.25);
+}
+@keyframes coverStreakGlow {
+  0%,
+  100% {
+    transform: translateY(4%);
+    opacity: 0.55;
+  }
+  50% {
+    transform: translateY(-4%);
+    opacity: 0.9;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cover-streak-btn::before {
+    animation: none;
+  }
+}
+body[data-motion='reduced'] .cover-streak-btn::before {
+  animation: none;
 }
 
 .cover-command-label {


### PR DESCRIPTION
## Summary
- add a versioned streak progression controller that persists visit history inside `tx:haze:v1` with opt-out support and window helpers
- surface streak counts through animated badges in the command bar/cover nav, wire bootstrap to record daily visits, and emit toast/TTS feedback
- escalate humiliation/whisper behaviour based on streak tiers, unlock artist spotlights, and document QA/ghost-mode controls

## Testing
- npm test *(fails: existing tag toggle test throws when tts-toggle loads outside the browser)*

------
https://chatgpt.com/codex/tasks/task_e_68eb1d1d7f04832c97b724f164f8a9ef