### PR TITLE
Add command deck presets and integrate ritual systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ A modern, visually unified web app for exploring, filtering, and discovering art
 - Use the **Wipe log** action inside the overlay (or clear `localStorage['te.dossier.entries']` in the console) to purge local history instantly.
 - Dossier whispers respect the TTS intensity slider: higher intensities surface harsher `dossier_open` / `dossier_revisit` lines, while disabled TTS falls back to a soft on-screen caption inside the panel.
 
+## Command Deck
+
+- **KNEEL / CONFESS / SIREN / ESCAPE** sit in the inner command bar and the Fold cover navigation. Each preset rewrites the active tag filters, applies coordinated lighting/glow classes, and adjusts the humiliation audio slider:
+  - **Kneel** stacks `leash`, `viewer_on_leash`, and `restraints`, bumps ASMR intensity to 2, and nudges the pressure meter upward.
+  - **Confess** pushes `humiliation`, `body_writing`, and `public_nudity`, keeps the indulgence low (lane 1), and sustains a softer glow.
+  - **Siren** floods `hypnosis`, `mind_break`, and `orgasm_denial`, maxes indulgence (lane 3), and fires a brighter alarm pulse plus a bass hit.
+  - **Escape** restores the last manual tag snapshot, drops indulgence to 0, and bleeds off pressure.
+- Button presses trigger patterned vibrations via `modules/ui.js` and dispatch bespoke whisper lines through the TTS dispatcher; the current preset, baseline tag snapshot, and indulgence lane persist in `localStorage['tx:haze:v1']` under the `commandDeck` key.
+- Keyboard shortcuts mirror the UI: **Shift+K** (Kneel), **Shift+C** (Confess), **Shift+S** (Siren), and **Shift+E** (Escape). Cover and inner layouts share the same state, so switching fold modes keeps the active preset.
+- **QA scenarios**:
+  - Confirm presets on both Fold cover and inner layouts (the cover deck collapses to a 2×2 grid and the inner buttons hide when `data-fold-mode="fold-cover"`).
+  - Enable `prefers-reduced-motion` (or the in-app motion toggle) to ensure the deck falls back to the CSS pulse instead of Motion One timelines.
+  - Reload after engaging a preset to verify the command deck, indulgence slider, and glow state hydrate from `tx:haze:v1`.
+
 ## Shame Pressure Meter
 
 - The landing hero now replaces its CTA stack with a persistent **Shame Pressure** meter. It fills from the `tx:haze:v1` namespace in `localStorage`, mirroring the current `pressureMeterLevel` whenever you return to the site.

--- a/modules/components/command-bar.js
+++ b/modules/components/command-bar.js
@@ -50,6 +50,72 @@ template.innerHTML = `
             FETCH
           </button>
         </div>
+        <div class="command-deck" role="group" aria-label="Command deck controls">
+          <button
+            id="command-kneel"
+            class="control-btn command-btn command-deck__btn command-deck__btn--kneel"
+            type="button"
+            data-command-action="kneel"
+            data-haptic="command"
+            aria-pressed="false"
+            aria-describedby="command-kneel-desc"
+            aria-label="Kneel preset. Adds leash and restraint tags to the gallery filters."
+          >
+            <span class="command-deck__glyph" aria-hidden="true">⟟</span>
+            <span class="command-deck__label">KNEEL</span>
+            <span id="command-kneel-desc" class="sr-only">
+              Queue leash, restraint, and viewer-on-leash tags while intensifying the glow.
+            </span>
+          </button>
+          <button
+            id="command-confess"
+            class="control-btn command-btn command-deck__btn command-deck__btn--confess"
+            type="button"
+            data-command-action="confess"
+            data-haptic="command"
+            aria-pressed="false"
+            aria-describedby="command-confess-desc"
+            aria-label="Confess preset. Pushes humiliation and public exposure filters."
+          >
+            <span class="command-deck__glyph" aria-hidden="true">✧</span>
+            <span class="command-deck__label">CONFESS</span>
+            <span id="command-confess-desc" class="sr-only">
+              Layer humiliation, public nudity, and body writing to broadcast every secret.
+            </span>
+          </button>
+          <button
+            id="command-siren"
+            class="control-btn command-btn command-deck__btn command-deck__btn--siren"
+            type="button"
+            data-command-action="siren"
+            data-haptic="command"
+            aria-pressed="false"
+            aria-describedby="command-siren-desc"
+            aria-label="Siren preset. Floods trance and denial tags while spiking the ambience."
+          >
+            <span class="command-deck__glyph" aria-hidden="true">⚠</span>
+            <span class="command-deck__label">SIREN</span>
+            <span id="command-siren-desc" class="sr-only">
+              Engage emergency trance: hypnosis, mind break, and denial tags plus alarmed lighting.
+            </span>
+          </button>
+          <button
+            id="command-escape"
+            class="control-btn command-btn command-deck__btn command-deck__btn--escape"
+            type="button"
+            data-command-action="escape"
+            data-haptic="command"
+            aria-pressed="false"
+            aria-describedby="command-escape-desc"
+            aria-label="Escape preset. Clears command filters and calms the ambience."
+          >
+            <span class="command-deck__glyph" aria-hidden="true">⎋</span>
+            <span class="command-deck__label">ESCAPE</span>
+            <span id="command-escape-desc" class="sr-only">
+              Release the deck influence, restore your saved tags, and drop the indulgence to zero.
+            </span>
+          </button>
+        </div>
         <div class="command-streak" role="group" aria-label="Return streak tracker">
           <button
             id="streak-chip"
@@ -73,6 +139,7 @@ template.innerHTML = `
           <span class="command-status__label" data-mode="cover">COVER MODE</span>
           <span class="command-status__label" data-mode="inner">INNER MODE</span>
         </div>
+        <span class="sr-only" id="command-deck-announcement" aria-live="polite"></span>
       </nav>
     </div>
     <div class="command-bar-safe-area command-bar-safe-area--bottom" data-region="cover">
@@ -108,6 +175,72 @@ template.innerHTML = `
           <span aria-hidden="true">⛓</span>
           <span class="cover-command-label">Filters</span>
         </button>
+        <div class="cover-command-deck" role="group" aria-label="Command deck controls">
+          <button
+            id="cover-command-kneel"
+            class="cover-command-btn cover-command-deck__btn cover-command-deck__btn--kneel"
+            type="button"
+            data-command-action="kneel"
+            data-haptic="command"
+            aria-pressed="false"
+            aria-describedby="cover-command-kneel-desc"
+            aria-label="Kneel preset. Adds leash and restraint tags to the gallery filters."
+          >
+            <span class="cover-command-deck__glyph" aria-hidden="true">⟟</span>
+            <span class="cover-command-label">Kneel</span>
+            <span id="cover-command-kneel-desc" class="sr-only">
+              Queue leash, restraint, and viewer-on-leash tags while intensifying the glow.
+            </span>
+          </button>
+          <button
+            id="cover-command-confess"
+            class="cover-command-btn cover-command-deck__btn cover-command-deck__btn--confess"
+            type="button"
+            data-command-action="confess"
+            data-haptic="command"
+            aria-pressed="false"
+            aria-describedby="cover-command-confess-desc"
+            aria-label="Confess preset. Pushes humiliation and public exposure filters."
+          >
+            <span class="cover-command-deck__glyph" aria-hidden="true">✧</span>
+            <span class="cover-command-label">Confess</span>
+            <span id="cover-command-confess-desc" class="sr-only">
+              Layer humiliation, public nudity, and body writing to broadcast every secret.
+            </span>
+          </button>
+          <button
+            id="cover-command-siren"
+            class="cover-command-btn cover-command-deck__btn cover-command-deck__btn--siren"
+            type="button"
+            data-command-action="siren"
+            data-haptic="command"
+            aria-pressed="false"
+            aria-describedby="cover-command-siren-desc"
+            aria-label="Siren preset. Floods trance and denial tags while spiking the ambience."
+          >
+            <span class="cover-command-deck__glyph" aria-hidden="true">⚠</span>
+            <span class="cover-command-label">Siren</span>
+            <span id="cover-command-siren-desc" class="sr-only">
+              Engage emergency trance: hypnosis, mind break, and denial tags plus alarmed lighting.
+            </span>
+          </button>
+          <button
+            id="cover-command-escape"
+            class="cover-command-btn cover-command-deck__btn cover-command-deck__btn--escape"
+            type="button"
+            data-command-action="escape"
+            data-haptic="command"
+            aria-pressed="false"
+            aria-describedby="cover-command-escape-desc"
+            aria-label="Escape preset. Clears command filters and calms the ambience."
+          >
+            <span class="cover-command-deck__glyph" aria-hidden="true">⎋</span>
+            <span class="cover-command-label">Escape</span>
+            <span id="cover-command-escape-desc" class="sr-only">
+              Release the deck influence, restore your saved tags, and drop the indulgence to zero.
+            </span>
+          </button>
+        </div>
         <button
           id="cover-streak-btn"
           class="cover-command-btn cover-streak-btn"

--- a/modules/pages/gallery.js
+++ b/modules/pages/gallery.js
@@ -45,6 +45,8 @@ import {
   setupInfiniteScroll,
   setupBackgroundRotation,
   showToast,
+  vibrate,
+  vibratePattern,
 } from '../ui.js';
 import {
   loadAppData,
@@ -74,6 +76,7 @@ import {
   getDossierEntries,
 } from '../shame-dossier.js';
 import { incrementPressure } from '../progression/pressure-meter.js';
+import { setIndulgenceLevel } from '../audio/humiliation-audio.js';
 import {
   recordVisit as recordStreakVisit,
   getStreakState as getStreakSnapshot,
@@ -91,12 +94,581 @@ const scheduleMicrotask = typeof queueMicrotask === 'function'
   ? (callback) => queueMicrotask(callback)
   : (callback) => Promise.resolve().then(callback);
 
+const COMMAND_STORAGE_NAMESPACE = 'tx:haze:v1';
+const COMMAND_STORAGE_KEY = 'commandDeck';
+
+const COMMAND_KEYBOARD_BINDINGS = {
+  KeyK: 'kneel',
+  KeyC: 'confess',
+  KeyS: 'siren',
+  KeyE: 'escape',
+};
+
+const COMMAND_PRESETS = {
+  kneel: {
+    id: 'kneel',
+    label: 'KNEEL',
+    tagsAdd: ['leash', 'viewer_on_leash', 'restraints'],
+    tagsRemove: ['humiliation', 'body_writing', 'public_nudity', 'mind_break', 'hypnosis', 'orgasm_denial'],
+    asmrLevel: 2,
+    pressureDelta: 8,
+    minIntensity: 2,
+    maxIntensity: 3,
+    whisper: 'Down. Knees on the glass and leash tags locked.',
+    announcement: 'Command deck engaged: Kneel preset stacked restraints and leash filters.',
+    haptic: [20, 26, 20],
+    bass: { intensity: 0.64, durationMs: 480 },
+  },
+  confess: {
+    id: 'confess',
+    label: 'CONFESS',
+    tagsAdd: ['humiliation', 'body_writing', 'public_nudity'],
+    tagsRemove: ['leash', 'viewer_on_leash', 'restraints', 'hypnosis', 'mind_break', 'orgasm_denial'],
+    asmrLevel: 1,
+    pressureDelta: 6,
+    minIntensity: 1,
+    maxIntensity: 3,
+    whisper: 'Confess everything. Let the gallery read every humiliating detail.',
+    announcement: 'Command deck engaged: Confess preset broadcasting humiliation filters.',
+    haptic: [18, 18, 32],
+    bass: { intensity: 0.52, durationMs: 420 },
+  },
+  siren: {
+    id: 'siren',
+    label: 'SIREN',
+    tagsAdd: ['hypnosis', 'mind_break', 'orgasm_denial'],
+    tagsRemove: ['humiliation', 'body_writing', 'public_nudity', 'leash', 'viewer_on_leash', 'restraints'],
+    asmrLevel: 3,
+    pressureDelta: 10,
+    minIntensity: 2,
+    maxIntensity: 3,
+    whisper: 'Siren triggered. Hypnosis, denial, and mind-break queued on repeat.',
+    announcement: 'Command deck engaged: Siren preset floods trance and denial filters.',
+    haptic: [24, 18, 24, 18, 32],
+    bass: { intensity: 0.82, durationMs: 640, allowInCover: true },
+  },
+  escape: {
+    id: 'escape',
+    label: 'ESCAPE',
+    tagsAdd: [],
+    tagsRemove: [],
+    asmrLevel: 0,
+    pressureDelta: -12,
+    minIntensity: 1,
+    maxIntensity: 2,
+    whisper: 'Run then. Your shame log stays warm for when you crawl back.',
+    announcement: 'Command deck cleared. Restored your saved filters and muted indulgence.',
+    haptic: [18, 32, 22, 48],
+    bass: { intensity: 0.42, durationMs: 420 },
+  },
+};
+
+const COMMAND_DEFAULT_STATE = {
+  active: null,
+  baselineTags: [],
+  lastManualTags: [],
+  lastAppliedAt: 0,
+  asmrLevel: 0,
+};
+
+let commandDeckState = { ...COMMAND_DEFAULT_STATE };
+let commandButtons = new Map();
+let commandAnnouncer = null;
+let commandMotionPromise = null;
+let commandPulseTimer = null;
+let commandStorageFaultLogged = false;
+
 let ritualHost = null;
 let ritualQueue = [];
 let currentRitualActivation = null;
 let currentRitualElement = null;
 let ritualElementCleanup = [];
 let ritualFoldMode = 'default';
+
+
+function sanitizeTagList(tags) {
+  if (!Array.isArray(tags)) return [];
+  const seen = new Set();
+  const cleaned = [];
+  tags.forEach((tag) => {
+    if (typeof tag !== 'string') {
+      if (tag == null) return;
+      tag = String(tag);
+    }
+    const normalized = tag.trim().toLowerCase().replace(/\s+/g, '_');
+    if (!normalized || seen.has(normalized)) return;
+    seen.add(normalized);
+    cleaned.push(normalized);
+  });
+  return cleaned.slice(0, 32);
+}
+
+function readCommandNamespace() {
+  if (typeof window === 'undefined' || !window.localStorage) return {};
+  try {
+    const raw = window.localStorage.getItem(COMMAND_STORAGE_NAMESPACE);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return {};
+    return parsed;
+  } catch (error) {
+    if (!commandStorageFaultLogged) {
+      console.warn('[gallery] command deck storage read failed', error);
+      commandStorageFaultLogged = true;
+    }
+    return {};
+  }
+}
+
+function loadCommandDeckState() {
+  const namespace = readCommandNamespace();
+  const stored = namespace?.[COMMAND_STORAGE_KEY];
+  if (!stored || typeof stored !== 'object') {
+    commandDeckState = { ...COMMAND_DEFAULT_STATE };
+    return commandDeckState;
+  }
+  const activeKey = typeof stored.active === 'string' && COMMAND_PRESETS[stored.active]
+    ? stored.active
+    : null;
+  commandDeckState = {
+    active: activeKey,
+    baselineTags: sanitizeTagList(stored.baselineTags),
+    lastManualTags: sanitizeTagList(stored.lastManualTags),
+    lastAppliedAt: Number(stored.lastAppliedAt) || 0,
+    asmrLevel: Number(stored.asmrLevel) || 0,
+  };
+  if (!commandDeckState.baselineTags.length && commandDeckState.lastManualTags.length) {
+    commandDeckState.baselineTags = commandDeckState.lastManualTags.slice();
+  }
+  return commandDeckState;
+}
+
+function persistCommandDeckState() {
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  const payload = readCommandNamespace();
+  payload[COMMAND_STORAGE_KEY] = {
+    active: typeof commandDeckState.active === 'string' ? commandDeckState.active : null,
+    baselineTags: sanitizeTagList(commandDeckState.baselineTags),
+    lastManualTags: sanitizeTagList(commandDeckState.lastManualTags),
+    lastAppliedAt: Number(commandDeckState.lastAppliedAt) || Date.now(),
+    asmrLevel: Number(commandDeckState.asmrLevel) || 0,
+  };
+  try {
+    window.localStorage.setItem(COMMAND_STORAGE_NAMESPACE, JSON.stringify(payload));
+  } catch (error) {
+    if (!commandStorageFaultLogged) {
+      console.warn('[gallery] command deck storage write failed', error);
+      commandStorageFaultLogged = true;
+    }
+  }
+}
+
+function applyCommandVisualState(commandId) {
+  const normalized = typeof commandId === 'string' && commandId ? commandId : null;
+  const assign = (node) => {
+    if (!node || !node.dataset) return;
+    if (normalized) {
+      node.dataset.commandState = normalized;
+    } else {
+      delete node.dataset.commandState;
+    }
+  };
+  assign(document.documentElement);
+  assign(document.body);
+  assign(document.querySelector('.command-bar-shell'));
+  assign(document.querySelector('.cover-command-bar'));
+  assign(document.querySelector('.command-deck'));
+  assign(document.querySelector('.cover-command-deck'));
+}
+
+function updateCommandDeckButtons() {
+  const active = typeof commandDeckState.active === 'string' ? commandDeckState.active : null;
+  commandButtons.forEach((buttonSet, commandId) => {
+    buttonSet.forEach((btn) => {
+      if (!(btn instanceof HTMLElement)) return;
+      const isActive = active === commandId;
+      btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      btn.classList.toggle('is-active', isActive);
+    });
+  });
+}
+
+function announceCommand(message) {
+  if (!commandAnnouncer) return;
+  commandAnnouncer.textContent = message || '';
+}
+
+function shouldReduceMotionForCommands() {
+  if (typeof document === 'undefined' || typeof window === 'undefined') return true;
+  const motionDataset = document.body?.dataset?.motion || document.documentElement?.dataset?.motion;
+  if (motionDataset === 'reduced') return true;
+  try {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  } catch (error) {
+    return false;
+  }
+}
+
+async function loadCommandMotionModule() {
+  if (shouldReduceMotionForCommands()) return null;
+  if (!commandMotionPromise) {
+    commandMotionPromise = import('https://cdn.jsdelivr.net/npm/motion@10.16.4/+esm')
+      .catch((error) => {
+        console.warn('[gallery] command motion import failed', error);
+        return null;
+      });
+  }
+  try {
+    return await commandMotionPromise;
+  } catch (error) {
+    console.warn('[gallery] command motion load failed', error);
+    return null;
+  }
+}
+
+function hexToRGBA(value, alpha = 1) {
+  const hex = String(value || '').trim();
+  const match = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(hex);
+  if (!match) return `rgba(102, 243, 255, ${alpha})`;
+  let hexValue = match[1];
+  if (hexValue.length === 3) {
+    hexValue = hexValue.split('').map((ch) => ch + ch).join('');
+  }
+  const num = parseInt(hexValue, 16);
+  const r = (num >> 16) & 255;
+  const g = (num >> 8) & 255;
+  const b = num & 255;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function getCommandAccentColor() {
+  if (typeof document === 'undefined') return '#66f3ff';
+  try {
+    const computed = getComputedStyle(document.body);
+    const value = computed.getPropertyValue('--command-accent');
+    return value ? value.trim() || '#66f3ff' : '#66f3ff';
+  } catch (error) {
+    return '#66f3ff';
+  }
+}
+
+function buildCommandAnimationSteps(commandId) {
+  const steps = [];
+  if (typeof document === 'undefined') return steps;
+  const shell = document.querySelector('.command-bar-shell');
+  const background = document.querySelector('.background-lattice');
+  const deck = document.querySelector('.command-deck');
+  const coverDeck = document.querySelector('.cover-command-deck');
+  const isCover = document.body?.dataset?.foldMode === 'fold-cover';
+  const deckTarget = isCover && coverDeck ? coverDeck : deck;
+  const accent = getCommandAccentColor();
+  const accentGlow = hexToRGBA(accent, 0.55);
+  const accentSoft = hexToRGBA(accent, 0.28);
+
+  if (deckTarget) {
+    steps.push([
+      deckTarget,
+      {
+        transform: ['scale(0.96)', 'scale(1.06)', 'scale(1)'],
+        boxShadow: ['0 0 0 rgba(0,0,0,0)', `0 26px 58px -26px ${accentGlow}`, `0 16px 32px -28px ${accentSoft}`],
+      },
+      { duration: 0.72, easing: 'cubic-bezier(.4,-0.2,.2,1.2)' },
+    ]);
+  }
+  if (shell) {
+    steps.push([
+      shell,
+      {
+        transform: ['translateY(-10px)', 'translateY(0)'],
+        filter: ['drop-shadow(0 0 0 rgba(0,0,0,0))', `drop-shadow(0 18px 42px ${accentGlow})`],
+      },
+      { duration: 0.78, easing: 'cubic-bezier(.4,-0.2,.2,1.2)', at: '<' },
+    ]);
+  }
+  if (background) {
+    const filters = {
+      kneel: ['saturate(0.95) brightness(0.92)', 'saturate(1.22) brightness(1.12)'],
+      confess: ['saturate(0.9) brightness(0.9)', 'saturate(1.28) brightness(1.1)'],
+      siren: ['saturate(1) brightness(0.9)', 'saturate(1.38) brightness(1.16)'],
+      escape: ['saturate(0.9) brightness(0.88)', 'saturate(1) brightness(0.96)'],
+    };
+    const filterFrames = filters[commandId] || ['saturate(0.95)', 'saturate(1.1)'];
+    steps.push([
+      background,
+      { filter: filterFrames },
+      { duration: 1.1, easing: 'ease-out', at: '<' },
+    ]);
+  }
+  if (commandId === 'siren' && deckTarget) {
+    steps.push([
+      deckTarget,
+      {
+        opacity: [1, 0.82, 1],
+        filter: ['drop-shadow(0 0 0 rgba(0,0,0,0))', `drop-shadow(0 0 22px ${accentGlow})`, `drop-shadow(0 0 10px ${accentSoft})`],
+      },
+      { duration: 1.4, easing: 'ease-out', at: 0.08 },
+    ]);
+  }
+  return steps;
+}
+
+function applyCommandFallbackPulse() {
+  if (typeof document === 'undefined') return;
+  const deck = document.querySelector('.command-deck');
+  const coverDeck = document.querySelector('.cover-command-deck');
+  [deck, coverDeck].forEach((node) => {
+    if (!node) return;
+    node.classList.add('command-deck--pulse');
+  });
+  if (commandPulseTimer) clearTimeout(commandPulseTimer);
+  commandPulseTimer = setTimeout(() => {
+    [deck, coverDeck].forEach((node) => node && node.classList.remove('command-deck--pulse'));
+  }, 420);
+}
+
+async function runCommandAnimation(commandId, { silent = false } = {}) {
+  if (silent) {
+    applyCommandFallbackPulse();
+    return;
+  }
+  if (!commandId || shouldReduceMotionForCommands()) {
+    applyCommandFallbackPulse();
+    return;
+  }
+  const motion = await loadCommandMotionModule();
+  if (!motion || typeof motion.timeline !== 'function') {
+    applyCommandFallbackPulse();
+    return;
+  }
+  const steps = buildCommandAnimationSteps(commandId);
+  if (!steps.length) {
+    applyCommandFallbackPulse();
+    return;
+  }
+  try {
+    motion.timeline(steps, {
+      defaultOptions: {
+        duration: 0.86,
+        easing: 'cubic-bezier(.4,-0.2,.2,1.2)',
+        fill: 'forwards',
+      },
+    });
+  } catch (error) {
+    console.warn('[gallery] command animation failed', error);
+    applyCommandFallbackPulse();
+  }
+}
+
+function handleCommandEscape({ silent = false, source = 'button' } = {}) {
+  const preset = COMMAND_PRESETS.escape;
+  let baseline = commandDeckState.baselineTags.length
+    ? commandDeckState.baselineTags.slice()
+    : commandDeckState.lastManualTags.length
+    ? commandDeckState.lastManualTags.slice()
+    : sanitizeTagList(Array.from((typeof getActiveTags === 'function' ? getActiveTags() : []) || []));
+  if (!baseline.length) {
+    baseline = [];
+  }
+  hydrateTagState(baseline);
+  if (typeof setRandomBackground === 'function') {
+    setRandomBackground();
+  }
+  try {
+    setIndulgenceLevel(preset.asmrLevel ?? 0, { source: 'command-deck' });
+    commandDeckState.asmrLevel = preset.asmrLevel ?? 0;
+  } catch (error) {
+    if (!commandStorageFaultLogged) {
+      console.warn('[gallery] command deck indulgence reset failed', error);
+    }
+  }
+  if (!silent && Number.isFinite(preset.pressureDelta) && preset.pressureDelta !== 0) {
+    incrementPressure(preset.pressureDelta, { source: 'command:escape' });
+  }
+  if (!silent && preset.bass) {
+    try {
+      triggerBassPulse({ ...preset.bass });
+    } catch (error) {
+      console.warn('[gallery] bass pulse failed for escape command', error);
+    }
+  }
+  if (!silent && preset.whisper) {
+    dispatchWhisperEvent('command_escape', {
+      text: preset.whisper,
+      minIntensity: preset.minIntensity ?? 1,
+      maxIntensity: preset.maxIntensity ?? 2,
+    });
+  }
+  if (!silent) {
+    if (Array.isArray(preset.haptic)) {
+      vibratePattern(preset.haptic);
+    } else {
+      vibrate(32);
+    }
+  }
+  commandDeckState.active = null;
+  commandDeckState.baselineTags = sanitizeTagList(baseline);
+  commandDeckState.lastManualTags = commandDeckState.baselineTags.slice();
+  commandDeckState.lastAppliedAt = Date.now();
+  applyCommandVisualState(null);
+  updateCommandDeckButtons();
+  if (!silent) {
+    announceCommand(preset.announcement || 'Command deck cleared.');
+  }
+  runCommandAnimation('escape', { silent });
+  persistCommandDeckState();
+}
+
+function handleCommandAction(commandId, { silent = false, source = 'button', preserveBaseline = false } = {}) {
+  const normalized = String(commandId || '').toLowerCase();
+  if (!normalized) return;
+  if (normalized === 'escape') {
+    handleCommandEscape({ silent, source });
+    return;
+  }
+  const preset = COMMAND_PRESETS[normalized];
+  if (!preset) return;
+  if (!preserveBaseline && !commandDeckState.active) {
+    try {
+      const snapshot = sanitizeTagList(Array.from(getActiveTags()));
+      if (snapshot.length) {
+        commandDeckState.baselineTags = snapshot;
+        commandDeckState.lastManualTags = snapshot.slice();
+      }
+    } catch (error) {
+      commandDeckState.baselineTags = [];
+    }
+  }
+  const baseline = commandDeckState.baselineTags.length
+    ? commandDeckState.baselineTags.slice()
+    : sanitizeTagList(Array.from((typeof getActiveTags === 'function' ? getActiveTags() : []) || []));
+  const nextTagsSet = new Set(baseline);
+  (preset.tagsRemove || []).forEach((tag) => nextTagsSet.delete(tag));
+  (preset.tagsAdd || []).forEach((tag) => nextTagsSet.add(tag));
+  const nextTags = Array.from(nextTagsSet);
+  hydrateTagState(nextTags);
+  if (typeof setRandomBackground === 'function') {
+    setRandomBackground();
+  }
+  try {
+    const nextLevel = Number(preset.asmrLevel ?? commandDeckState.asmrLevel ?? 0);
+    setIndulgenceLevel(nextLevel, { source: 'command-deck' });
+    commandDeckState.asmrLevel = nextLevel;
+  } catch (error) {
+    if (!commandStorageFaultLogged) {
+      console.warn('[gallery] command deck indulgence sync failed', error);
+    }
+  }
+  if (!silent && Number.isFinite(preset.pressureDelta) && preset.pressureDelta !== 0) {
+    incrementPressure(preset.pressureDelta, { source: `command:${normalized}` });
+  }
+  if (!silent && preset.bass) {
+    try {
+      triggerBassPulse({ ...preset.bass });
+    } catch (error) {
+      console.warn('[gallery] bass pulse failed for command', error);
+    }
+  }
+  if (!silent && preset.whisper) {
+    dispatchWhisperEvent(`command_${normalized}`, {
+      text: preset.whisper,
+      minIntensity: preset.minIntensity ?? 1,
+      maxIntensity: preset.maxIntensity ?? 3,
+    });
+  }
+  commandDeckState.active = normalized;
+  commandDeckState.lastAppliedAt = Date.now();
+  applyCommandVisualState(normalized);
+  updateCommandDeckButtons();
+  if (!silent) {
+    announceCommand(preset.announcement || `${preset.label || normalized} preset engaged.`);
+  }
+  runCommandAnimation(normalized, { silent });
+  if (!silent) {
+    if (Array.isArray(preset.haptic)) {
+      vibratePattern(preset.haptic);
+    } else {
+      vibrate(36);
+    }
+  }
+  persistCommandDeckState();
+}
+
+async function setupCommandDeck() {
+  if (typeof document === 'undefined') return () => {};
+  await customElements.whenDefined('te-command-bar');
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+  commandAnnouncer = document.getElementById('command-deck-announcement') || null;
+  commandButtons = new Map();
+  const buttonCleanups = [];
+  const buttonNodes = Array.from(document.querySelectorAll('[data-command-action]'));
+  buttonNodes.forEach((btn) => {
+    if (!(btn instanceof HTMLElement)) return;
+    const commandId = String(btn.dataset.commandAction || '').toLowerCase();
+    if (!commandId) return;
+    if (!commandButtons.has(commandId)) {
+      commandButtons.set(commandId, new Set());
+    }
+    commandButtons.get(commandId).add(btn);
+    const onClick = () => handleCommandAction(commandId, { source: 'button' });
+    btn.addEventListener('click', onClick);
+    buttonCleanups.push(() => btn.removeEventListener('click', onClick));
+  });
+  loadCommandDeckState();
+  if (!commandDeckState.lastManualTags.length) {
+    try {
+      const snapshot = sanitizeTagList(Array.from(getActiveTags()));
+      commandDeckState.lastManualTags = snapshot;
+      commandDeckState.baselineTags = snapshot.slice();
+    } catch (error) {
+      commandDeckState.lastManualTags = [];
+      commandDeckState.baselineTags = [];
+    }
+  }
+  if (commandDeckState.active && COMMAND_PRESETS[commandDeckState.active]) {
+    applyCommandVisualState(commandDeckState.active);
+    handleCommandAction(commandDeckState.active, { silent: true, source: 'hydrate', preserveBaseline: true });
+  } else {
+    applyCommandVisualState(null);
+    updateCommandDeckButtons();
+  }
+  if (commandAnnouncer) {
+    announceCommand('Command deck ready. Shift+K kneels, Shift+C confesses, Shift+S triggers the siren, Shift+E escapes.');
+  }
+  persistCommandDeckState();
+  const handleTagsUpdate = (event) => {
+    if (commandDeckState.active) return;
+    const nextTags = Array.isArray(event?.detail?.activeTags)
+      ? sanitizeTagList(event.detail.activeTags)
+      : sanitizeTagList(Array.from((typeof getActiveTags === 'function' ? getActiveTags() : []) || []));
+    commandDeckState.lastManualTags = nextTags;
+    commandDeckState.baselineTags = nextTags.slice();
+    persistCommandDeckState();
+  };
+  document.addEventListener('tags:updated', handleTagsUpdate);
+  const handleKeydown = (event) => {
+    if (!event || event.defaultPrevented) return;
+    if (!event.shiftKey || event.altKey || event.ctrlKey || event.metaKey) return;
+    const target = event.target;
+    const tagName = target?.tagName;
+    if (tagName) {
+      const normalized = tagName.toLowerCase();
+      if (['input', 'textarea', 'select'].includes(normalized)) return;
+    }
+    if (target?.isContentEditable) return;
+    const commandId = COMMAND_KEYBOARD_BINDINGS[event.code];
+    if (!commandId) return;
+    event.preventDefault();
+    handleCommandAction(commandId, { source: 'keyboard' });
+  };
+  document.addEventListener('keydown', handleKeydown);
+  return () => {
+    buttonCleanups.forEach((cleanup) => cleanup());
+    document.removeEventListener('tags:updated', handleTagsUpdate);
+    document.removeEventListener('keydown', handleKeydown);
+    commandButtons.clear();
+    commandAnnouncer = null;
+  };
+}
 
 function readMotionPreference() {
   if (typeof window === 'undefined') return MOTION_DEFAULT;
@@ -1243,6 +1815,8 @@ export async function initGalleryPage({ foldAdapter } = {}) {
   setupFavoritesButton();
   setupDossierButton();
 
+  const commandDeckCleanup = await setupCommandDeck();
+
   const idleCleanup = setupIdleWhispers();
 
   window.kexplorer = {
@@ -1284,6 +1858,9 @@ export async function initGalleryPage({ foldAdapter } = {}) {
       if (typeof idleCleanup === 'function') idleCleanup();
       if (pressureProgression && typeof pressureProgression.dispose === 'function') {
         pressureProgression.dispose();
+      }
+      if (typeof commandDeckCleanup === 'function') {
+        commandDeckCleanup();
       }
       if (typeof ritualCleanup === 'function') {
         ritualCleanup();

--- a/modules/ui.js
+++ b/modules/ui.js
@@ -565,6 +565,13 @@ function vibrate(ms = 30) {
   }
 }
 
+function vibratePattern(pattern = [20, 35, 20]) {
+  if (window.navigator && typeof window.navigator.vibrate === "function") {
+    const sequence = Array.isArray(pattern) ? pattern : [pattern];
+    window.navigator.vibrate(sequence);
+  }
+}
+
 /**
  * Triggers a screen pulse effect (CSS + accessibility)
  */
@@ -618,5 +625,6 @@ export {
   scrollToTop,
   createConfirmationModal,
   vibrate,
+  vibratePattern,
   pulseScreen,
 };

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -56,6 +56,11 @@ body {
 @apply min-h-screen bg-night text-slate-100 font-sans antialiased overflow-x-hidden;
 width: 100%;
 max-width: 100vw;
+--command-accent: #66f3ff;
+--command-backdrop: rgba(102, 243, 255, 0.18);
+--command-outline: rgba(102, 243, 255, 0.45);
+--command-shadow: 0 20px 50px -28px rgba(102, 243, 255, 0.45);
+--command-text-shadow: 0 0 20px rgba(102, 243, 255, 0.65);
 }
 body.shame-dossier-open {
 overflow: hidden;
@@ -68,6 +73,34 @@ body.incognito-theme {
 }
 body.incognito-theme .background-lattice {
 @apply opacity-60 filter grayscale;
+}
+body[data-command-state='kneel'] {
+--command-accent: #4ee3f5;
+--command-backdrop: rgba(78, 227, 245, 0.22);
+--command-outline: rgba(78, 227, 245, 0.55);
+--command-shadow: 0 26px 58px -26px rgba(78, 227, 245, 0.58);
+--command-text-shadow: 0 0 22px rgba(78, 227, 245, 0.72);
+}
+body[data-command-state='confess'] {
+--command-accent: #ff86d6;
+--command-backdrop: rgba(255, 134, 214, 0.24);
+--command-outline: rgba(255, 134, 214, 0.58);
+--command-shadow: 0 28px 64px -26px rgba(255, 134, 214, 0.6);
+--command-text-shadow: 0 0 22px rgba(255, 134, 214, 0.78);
+}
+body[data-command-state='siren'] {
+--command-accent: #ff4a6d;
+--command-backdrop: rgba(255, 74, 109, 0.26);
+--command-outline: rgba(255, 74, 109, 0.65);
+--command-shadow: 0 30px 70px -24px rgba(255, 74, 109, 0.64);
+--command-text-shadow: 0 0 26px rgba(255, 74, 109, 0.82);
+}
+body[data-command-state='escape'] {
+--command-accent: #7f8cff;
+--command-backdrop: rgba(127, 140, 255, 0.2);
+--command-outline: rgba(127, 140, 255, 0.52);
+--command-shadow: 0 24px 58px -28px rgba(127, 140, 255, 0.55);
+--command-text-shadow: 0 0 18px rgba(127, 140, 255, 0.68);
 }
 ::selection {
 @apply bg-blush/60 text-white;
@@ -91,6 +124,18 @@ border-radius: 9999px;
 .background-lattice::after {
 content: '';
 @apply absolute inset-0 bg-[linear-gradient(120deg,rgba(255,255,255,0.04)_0%,rgba(255,255,255,0)_32%,rgba(255,255,255,0.04)_64%,rgba(255,255,255,0)_100%)] opacity-60 mix-blend-screen pointer-events-none;
+}
+body[data-command-state='kneel'] .background-lattice {
+  filter: saturate(1.12) hue-rotate(-10deg) brightness(1.05);
+}
+body[data-command-state='confess'] .background-lattice {
+  filter: saturate(1.18) hue-rotate(12deg) brightness(1.08);
+}
+body[data-command-state='siren'] .background-lattice {
+  filter: saturate(1.28) hue-rotate(-28deg) brightness(1.12);
+}
+body[data-command-state='escape'] .background-lattice {
+  filter: saturate(0.94) hue-rotate(4deg) brightness(0.94);
 }
 .top-surface {
 @apply relative z-[70] w-full border-b border-white/10 bg-panel/80 backdrop-blur-glass flex flex-col;
@@ -153,6 +198,124 @@ pointer-events: none;
 }
 .command-bar-safe-area--bottom > .cover-command-bar {
   pointer-events: auto;
+}
+.command-bar-shell[data-command-state] .command-bar,
+.command-bar-shell[data-command-state] .cover-command-bar {
+  border-color: var(--command-outline);
+  box-shadow: var(--command-shadow);
+  background-image: linear-gradient(140deg, rgba(255, 255, 255, 0.04), transparent 45%);
+}
+.command-bar-shell[data-command-state]::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: 2.5rem;
+  opacity: 0.22;
+  box-shadow: 0 0 120px var(--command-backdrop);
+  transition: opacity 0.6s ease;
+}
+.command-bar-shell[data-command-state='escape']::after {
+  opacity: 0.16;
+}
+.command-deck {
+  @apply ml-6 flex flex-wrap items-center gap-2 border-l border-white/10 pl-4;
+  min-height: 2.75rem;
+}
+.command-deck__btn {
+  @apply relative inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-[0.55rem] font-semibold uppercase tracking-[0.35em] text-slate-200 shadow-inner transition-all duration-300 ease-kink focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2;
+  outline-color: var(--command-outline);
+  text-shadow: 0 0 12px rgba(255, 255, 255, 0.1);
+}
+.command-deck__btn::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 9999px;
+  opacity: 0;
+  background: radial-gradient(circle at 50% 50%, var(--command-accent) 0%, transparent 70%);
+  transition: opacity 0.35s ease;
+  pointer-events: none;
+}
+.command-deck__btn:hover::after,
+.command-deck__btn.is-active::after {
+  opacity: 0.35;
+}
+.command-deck__btn:hover,
+.command-deck__btn:focus-visible {
+  color: #fff;
+  border-color: var(--command-outline);
+  background-color: var(--command-backdrop);
+  background-color: color-mix(in srgb, var(--command-backdrop) 60%, transparent);
+  box-shadow: var(--command-shadow);
+}
+.command-deck__btn.is-active {
+  color: #fff;
+  border-color: var(--command-outline);
+  background-color: var(--command-backdrop);
+  box-shadow: var(--command-shadow);
+}
+.command-deck__glyph {
+  @apply text-lg;
+  color: var(--command-accent);
+}
+.command-deck__label {
+  letter-spacing: 0.34em;
+}
+.command-deck--pulse {
+  animation: commandDeckPulse 0.6s ease-out;
+}
+.cover-command-deck {
+  @apply mt-2 grid w-full grid-cols-2 gap-2 rounded-3xl border border-white/10 bg-black/50 px-3 py-2;
+}
+.cover-command-deck__btn {
+  @apply flex h-full flex-col items-center justify-center gap-1 rounded-2xl border border-white/10 bg-white/5 px-2 py-2 text-[0.58rem] font-semibold uppercase tracking-[0.28em] text-slate-200 transition-all duration-300 ease-kink focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2;
+  outline-color: var(--command-outline);
+  text-shadow: 0 0 10px rgba(255, 255, 255, 0.08);
+}
+.cover-command-deck__btn:hover,
+.cover-command-deck__btn:focus-visible {
+  color: #fff;
+  border-color: var(--command-outline);
+  background-color: var(--command-backdrop);
+  background-color: color-mix(in srgb, var(--command-backdrop) 50%, transparent);
+  box-shadow: var(--command-shadow);
+}
+.cover-command-deck__btn.is-active {
+  color: #fff;
+  border-color: var(--command-outline);
+  background-color: var(--command-backdrop);
+  box-shadow: var(--command-shadow);
+}
+.cover-command-deck__glyph {
+  @apply text-base;
+  color: var(--command-accent);
+}
+.cover-command-deck__btn .cover-command-label {
+  text-transform: uppercase;
+  font-size: 0.58rem;
+}
+body[data-fold-mode='fold-inner'] .cover-command-deck {
+  display: none;
+}
+body[data-fold-mode='fold-cover'] .command-deck {
+  display: none;
+}
+body[data-command-state='kneel'] .command-deck__btn.is-active,
+body[data-command-state='kneel'] .cover-command-deck__btn.is-active {
+  animation: commandKneelPulse 3.2s ease-in-out infinite;
+}
+body[data-command-state='confess'] .command-deck__btn.is-active,
+body[data-command-state='confess'] .cover-command-deck__btn.is-active {
+  animation: commandConfessSheen 3.8s ease-in-out infinite;
+}
+body[data-command-state='siren'] .command-deck__btn.is-active,
+body[data-command-state='siren'] .cover-command-deck__btn.is-active {
+  animation: commandSirenBeacon 2.4s ease-in-out infinite;
+}
+body[data-command-state='escape'] .command-deck__btn.is-active,
+body[data-command-state='escape'] .cover-command-deck__btn.is-active {
+  animation: commandEscapeCalm 4.2s ease-in-out infinite;
 }
 .ritual-overlay-host {
   position: fixed;
@@ -2582,6 +2745,72 @@ dialog[data-landing-ritual]::backdrop {
   z-index: 1;
 }
 
+@keyframes commandDeckPulse {
+  0% {
+    transform: translateY(0) scale(1);
+    box-shadow: none;
+  }
+  45% {
+    transform: translateY(-6px) scale(1.04);
+    box-shadow: var(--command-shadow);
+  }
+  100% {
+    transform: translateY(0) scale(1);
+    box-shadow: none;
+  }
+}
+@keyframes commandKneelPulse {
+  0%, 100% {
+    box-shadow: inset 0 0 0 0 rgba(78, 227, 245, 0.26);
+    transform: translateY(0);
+  }
+  48% {
+    box-shadow: inset 0 0 0 2px rgba(78, 227, 245, 0.55);
+    transform: translateY(-3px);
+  }
+  68% {
+    box-shadow: inset 0 0 0 0 rgba(78, 227, 245, 0.35);
+  }
+}
+@keyframes commandConfessSheen {
+  0%, 100% {
+    filter: drop-shadow(0 0 0 rgba(255, 134, 214, 0.2));
+    transform: translateY(0);
+  }
+  35% {
+    filter: drop-shadow(0 0 14px rgba(255, 134, 214, 0.62));
+    transform: translateY(-2px);
+  }
+  55% {
+    filter: drop-shadow(0 0 10px rgba(255, 134, 214, 0.48));
+  }
+}
+@keyframes commandSirenBeacon {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(255, 74, 109, 0);
+    transform: translateY(0);
+  }
+  32% {
+    box-shadow: 0 0 26px rgba(255, 74, 109, 0.65);
+    transform: translateY(-4px);
+  }
+  64% {
+    box-shadow: 0 0 18px rgba(255, 74, 109, 0.42);
+  }
+}
+@keyframes commandEscapeCalm {
+  0%, 100% {
+    filter: saturate(1) brightness(1);
+    transform: translateY(0);
+  }
+  45% {
+    filter: saturate(0.92) brightness(0.92);
+    transform: translateY(1px);
+  }
+  70% {
+    filter: saturate(1) brightness(0.98);
+  }
+}
 @media (prefers-reduced-motion: reduce) {
   dialog[data-landing-ritual]::backdrop {
     @apply backdrop-blur-none;
@@ -2596,6 +2825,11 @@ dialog[data-landing-ritual]::backdrop {
   }
   .landing-ritual__stage--active {
     transform: none;
+  }
+  .command-deck__btn.is-active,
+  .cover-command-deck__btn.is-active,
+  .command-deck--pulse {
+    animation: none !important;
   }
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,6 +19,12 @@ export default {
         glow: '#66f3ff',
         blush: '#ff64d4',
         ember: '#ff8257',
+        command: {
+          kneel: '#4ee3f5',
+          confess: '#ff86d6',
+          siren: '#ff4a6d',
+          escape: '#7f8cff',
+        },
         indulgence: {
           0: '#1b1830',
           1: '#2d1f45',
@@ -46,6 +52,10 @@ export default {
         'pressure-high': '0 0 42px rgba(255, 130, 87, 0.45)',
         'pressure-max': '0 0 48px rgba(255, 47, 100, 0.55)',
         'ritual-panel': '0 45px 95px -35px rgba(255, 99, 200, 0.52)',
+        'command-kneel': '0 22px 56px -28px rgba(78, 227, 245, 0.6)',
+        'command-confess': '0 24px 58px -30px rgba(255, 134, 214, 0.55)',
+        'command-siren': '0 26px 62px -28px rgba(255, 74, 109, 0.58)',
+        'command-escape': '0 22px 54px -28px rgba(127, 140, 255, 0.52)',
       },
       dropShadow: {
         ritual: '0 0 1.8rem rgba(255, 100, 212, 0.55)',


### PR DESCRIPTION
## Summary
- add the KNEEL/CONFESS/SIREN/ESCAPE command deck to the command bar and Fold cover navigation with accessible copy and announcers
- extend the UI helper with patterned haptic support and hook the gallery page up to presets, Motion One sequences, ASMR pressure, and persistence
- style and document the command deck states, including Tailwind tokens, animations, reduced-motion fallbacks, and QA/shortcut guidance

## Testing
- npm run test *(fails: existing tag toggle suite expects DOM controls for tts toggle)*

------
https://chatgpt.com/codex/tasks/task_e_68eb3cc10f60832c900fa197f36945ef