### PR TITLE
Guard TTS controls in tests

### DIFF
--- a/modules/tts-dispatcher.js
+++ b/modules/tts-dispatcher.js
@@ -419,7 +419,10 @@ function dispatchWhisperEvent(eventKey, options = {}) {
   return { text: line, intensity: lane };
 }
 
-if (typeof document !== 'undefined') {
+if (
+  typeof document !== 'undefined' &&
+  typeof document.addEventListener === 'function'
+) {
   document.addEventListener('tts:toggle', (event) => {
     const enabled = Boolean(event?.detail?.enabled);
     if (!enabled) {

--- a/modules/tts-toggle.js
+++ b/modules/tts-toggle.js
@@ -252,7 +252,11 @@ function updateIntensityControl() {
   btn.setAttribute("aria-label", `Whisper intensity ${label}${ariaSuffix}`);
   btn.setAttribute("data-intensity", String(intensity));
   btn.setAttribute("title", `Whisper intensity: ${label}`);
-  btn.classList.toggle("is-muted", !enabled || intensity === 0);
+  if (btn.classList && typeof btn.classList.toggle === "function") {
+    btn.classList.toggle("is-muted", !enabled || intensity === 0);
+  } else if (typeof btn.setAttribute === "function") {
+    btn.setAttribute("data-muted", (!enabled || intensity === 0) ? "true" : "false");
+  }
 }
 
 function updateTTSToggleButton() {


### PR DESCRIPTION
## Summary
- guard the whisper intensity control against missing classList in minimal DOM stubs
- ensure the dispatcher only wires toggle listeners when document.addEventListener exists

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eb42dcf164832c8b56f0ba65c033d4