### PR TITLE
Fix artist gallery image filtering

### DIFF
--- a/modules/gallery.js
+++ b/modules/gallery.js
@@ -8,6 +8,7 @@ import {
   fetchArtistStyleTags,
   getArtistSlug,
   getRandomBackgroundImage,
+  filterValidImagePosts,
 } from "./api.js";
 import { handleArtistCopy } from "./sidebar.js";
 import { pickThumbnailCandidateUrls } from "./thumbnail-chooser.js";
@@ -820,13 +821,9 @@ function setBestImage(artist, img) {
   }
 
   function processApiData(data, isFallback = false) {
-    const validPosts = Array.isArray(data)
-      ? data.filter((post) => {
-          const url = post?.large_file_url || post?.file_url;
-          const isImage = url && /\.(jpg|jpeg|png|gif)$/i.test(url);
-          return isImage && !post.is_banned;
-        })
-      : [];
+    const postsArray = Array.isArray(data) ? data : [];
+    const tagsForFilter = isFallback ? [] : selectedTags;
+    const validPosts = filterValidImagePosts(postsArray, tagsForFilter);
 
     if (validPosts.length === 0) {
       if (!isFallback && selectedTags.length > 0) {


### PR DESCRIPTION
## Summary
- reuse the shared API filter when picking artist thumbnails so modern file formats are accepted
- keep the existing fallback logic so cards still show something when tag-filtered posts are missing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ecd7103c24832c88fcd55af5693481