### PR TITLE
Stop including tag filters in artist API requests

### DIFF
--- a/modules/api.js
+++ b/modules/api.js
@@ -559,19 +559,18 @@ async function getRandomBackgroundImage(query = "chastity_cage") {
 
 // Accept paging options for fetchArtistImages
 async function fetchArtistImages(artistName, selectedTags = [], options = {}) {
-  // Send all selected tags to the API (no artificial client-side two-tag limit)
+  // Always query Danbooru with only the artist tag. Gallery filtering happens client-side.
   const page = Math.max(1, options.page || 1);
   const limit = options.limit || 200;
   const order = options.order || "approvals";
   const cacheSignature = [`p${page}`, `l${limit}`, `o${order}`].join("");
-  const tagSignature = Array.isArray(selectedTags) && selectedTags.length ? selectedTags.join(",") : "_all";
-  const apiCacheKey = `danbooru-api-${artistName}-${tagSignature}-${cacheSignature}`;
+  const apiCacheKey = `danbooru-api-${artistName}-${cacheSignature}`;
   const useCache = options.useCache !== false;
+
+  // Create deduplication key for this specific artist + paging request
+  const artistRequestKey = `${artistName}-${cacheSignature}`;
   
-  // Create deduplication key for this specific artist+tags API call
-  const artistRequestKey = `${artistName}-${tagSignature}-${cacheSignature}`;
-  
-  // Check if this exact artist+tags API call is already pending
+  // Check if this exact artist request is already pending
   if (pendingArtistRequests.has(artistRequestKey)) {
     const posts = await pendingArtistRequests.get(artistRequestKey);
     return filterValidImagePosts(posts, selectedTags);
@@ -596,8 +595,8 @@ async function fetchArtistImages(artistName, selectedTags = [], options = {}) {
     }
   }
   
-  // Create the API call promise - include artistName + all selectedTags
-  const apiPromise = fetchPosts([artistName, ...(Array.isArray(selectedTags) ? selectedTags : [])], {
+  // Create the API call promise using only the artist tag
+  const apiPromise = fetchPosts([artistName], {
     cacheKey: useCache ? apiCacheKey : null,
     useCache,
     limit,

--- a/modules/gallery.js
+++ b/modules/gallery.js
@@ -8,6 +8,7 @@ import {
   fetchArtistStyleTags,
   getArtistSlug,
   getRandomBackgroundImage,
+  filterValidImagePosts,
 } from "./api.js";
 import { handleArtistCopy } from "./sidebar.js";
 import { pickThumbnailCandidateUrls } from "./thumbnail-chooser.js";
@@ -792,8 +793,7 @@ function setBestImage(artist, img) {
   const _cache_limit = 200;
   const _cache_order = 'approvals';
   const cacheSignature = [`p${_cache_page}`, `l${_cache_limit}`, `o${_cache_order}`].join('');
-  const tagSignature = selectedTags.length ? selectedTags.join(',') : '_all';
-  const apiCacheKey = `danbooru-api-${artistData.artistName}-${tagSignature}-${cacheSignature}`;
+  const apiCacheKey = `danbooru-api-${artistData.artistName}-${cacheSignature}`;
 
   function getApiCache() {
     const cached = sessionStorage.getItem(apiCacheKey);
@@ -820,13 +820,9 @@ function setBestImage(artist, img) {
   }
 
   function processApiData(data, isFallback = false) {
-    const validPosts = Array.isArray(data)
-      ? data.filter((post) => {
-          const url = post?.large_file_url || post?.file_url;
-          const isImage = url && /\.(jpg|jpeg|png|gif)$/i.test(url);
-          return isImage && !post.is_banned;
-        })
-      : [];
+    const postsArray = Array.isArray(data) ? data : [];
+    const tagsForFilter = isFallback ? [] : selectedTags;
+    const validPosts = filterValidImagePosts(postsArray, tagsForFilter);
 
     if (validPosts.length === 0) {
       if (!isFallback && selectedTags.length > 0) {


### PR DESCRIPTION
## Summary
- update the shared API helper to always query Danbooru using only the artist tag while retaining client-side filtering
- align the gallery thumbnail cache keys with the simplified artist-only API signature so cached pages are reused across tag combinations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ecd7103c24832c88fcd55af5693481