### PR TITLE
Add TypeScript build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ azure-tts.local.js
 .github/prompts/promptsfile.prompt.md
 .github/chatmodes/chatmodes.chatmode.md
 node_modules
+dist/

--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ A modern, visually unified web app for exploring, filtering, and discovering art
 2. Open `index.html` in your browser
 3. Explore artists, tags, and sidebar features
 
+## Build & Type-Checking Workflow
+
+- Run `npm run build:css` to regenerate the Tailwind bundle whenever you tweak utility layers or add new components.
+- Run `npm run build:ts` to type-check and compile the browser-facing TypeScript under `src/` into `dist/` using the bundler-centric `tsconfig.json`.
+- Run `npm run build` to chain the CSS and TypeScript builds before serving locally or deploying the static bundle.
+- For future Node-based maintenance scripts written in TypeScript, target `tsconfig.scripts.json` to pull in the Node 16 resolution strategy and ambient `@types/node` definitions.
+
 ## Landing Ritual & Mission Storage
 
 - The landing page now opens with a whisper ritual that locks the **Enter Gallery** call-to-action until you pick a mission profile, consent to local logging, and confirm the choice.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "update:tags": "node scripts/updateKinkTags.js",
     "update:audio": "node scripts/generate-audio-list.js",
     "build:css": "tailwindcss -i styles/tailwind.css -o style.css --minify",
+    "build:ts": "tsc --project tsconfig.json",
+    "build": "npm run build:css && npm run build:ts",
     "serve": "npx http-server -c-1 . -p 8080 --silent"
   },
   "keywords": [],
@@ -15,6 +17,8 @@
   "license": "ISC",
   "type": "module",
   "devDependencies": {
-    "tailwindcss": "^3.4.13"
+    "@types/node": "^20.16.10",
+    "tailwindcss": "^3.4.13",
+    "typescript": "^5.6.3"
   }
 }

--- a/src/placeholder.ts
+++ b/src/placeholder.ts
@@ -1,0 +1,2 @@
+// Placeholder TypeScript module to keep the compiler configuration valid until the real browser sources are ported.
+export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "strict": true,
+    "noEmitOnError": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": []
+}

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./scripts",
+    "outDir": "./scripts",
+    "lib": ["ES2022"],
+    "moduleResolution": "node16",
+    "types": ["node"]
+  },
+  "include": ["scripts/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add TypeScript dev tooling and build scripts to package.json
- introduce browser and script-specific TypeScript configuration files
- document the new build workflow and ignore emitted JavaScript artifacts

## Testing
- npm run build:ts

------
https://chatgpt.com/codex/tasks/task_e_6902312e5f0c832c9a4befa83f6a929d