### PR TITLE
Fix fallback gallery image resolution

### DIFF
--- a/modules/fetch-cache.js
+++ b/modules/fetch-cache.js
@@ -1,9 +1,11 @@
+const FALLBACK_IMAGE_PLACEHOLDER = new URL('../fallback.jpg', import.meta.url).href;
+
 export async function fetchWithCache(url, options = {}) {
   const {
     cacheKey = url,
     useCache = true,
     type = 'json',
-    placeholder = 'fallback.jpg'
+    placeholder = FALLBACK_IMAGE_PLACEHOLDER
   } = options;
 
   const isBrowser = typeof window !== 'undefined';

--- a/modules/gallery.js
+++ b/modules/gallery.js
@@ -16,6 +16,8 @@ import { enhanceGalleryImages, injectImageQualityCss } from "./image-quality.js"
 import { showSimilarArtistsModal, setAllArtists as setSimilarArtists } from "./similar-artists.js";
 import { toggleFavorite, isFavorite } from "./favorites.js";
 
+const FALLBACK_IMAGE_URL = new URL('../fallback.jpg', import.meta.url).href;
+
 /**
  * Returns the thumbnail URL for an artist (used by sidebar and cards)
  */
@@ -984,7 +986,7 @@ function setBestImage(artist, img) {
 
   function showNoEntries() {
     img.style.display = "none";
-    img.src = "fallback.jpg";
+    img.src = FALLBACK_IMAGE_URL;
     setTimeout(() => {
       img.style.display = "block";
     }, 100);
@@ -1873,7 +1875,7 @@ function renderArtistCards(artists, selectedTagsOverride, options = 1) {
       img.src = cachedUrl;
       img.style.display = "block";
       img.onerror = () => {
-        img.src = "fallback.jpg";
+        img.src = FALLBACK_IMAGE_URL;
         img.style.display = "block";
       };
     } else {


### PR DESCRIPTION
## Summary
- ensure the gallery module resolves the fallback preview image relative to the module file
- reuse the same resolved fallback path whenever cached or placeholder images are required

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690262b67344832cbdc818e9c54824f4